### PR TITLE
rotate eletected validators

### DIFF
--- a/pallets/types.json
+++ b/pallets/types.json
@@ -124,7 +124,9 @@
   "DelegatorData": {
     "delegated_validators": "Vec<AccountId>"
   },
+  "EraIndex": "u32",
   "ValidatorData": {
-    "delegators": "Vec<AccountId>"
+    "delegators": "Vec<AccountId>",
+    "elected_era": "EraIndex"
   }
 }


### PR DESCRIPTION
The new elect() function rotates over validators so that all the validators have equal chance to be elected over long term