### PR TITLE
user input sessionid as u32:MAX, will cause overflowing

### DIFF
--- a/pallets/micropayment/src/lib.rs
+++ b/pallets/micropayment/src/lib.rs
@@ -311,7 +311,6 @@ pub mod pallet {
             Ok(().into())
         }
 
-
         /// Client adds more DPR tokens to the existing channel
         #[pallet::weight(T::WeightInfo::add_balance())]
         pub fn add_balance(
@@ -376,7 +375,10 @@ pub mod pallet {
             }
 
             if SessionId::<T>::contains_key((&client, &server))
-                && session_id != Self::session_id((&client, &server)).unwrap_or(0) + 1
+                && session_id
+                    != Self::session_id((&client, &server))
+                        .unwrap_or(0)
+                        .saturating_add(1)
             {
                 Err(Error::<T>::SessionError)?
             }
@@ -429,7 +431,6 @@ pub mod pallet {
     }
 
     impl<T: Config> Pallet<T> {
-
         /// Close the channel between the client and server
         fn _close_channel(client: &T::AccountId, server: &T::AccountId) {
             // remove all the session_ids of given channel


### PR DESCRIPTION
when user's first call this function with sessionid equal to u32:MAX,  
the second call this function will cause overflowing
