### PR TITLE
basic implementation of offchain_worker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1468,6 +1468,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethabi"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f76ef192b63e8a44b3d08832acebbb984c3fba154b5c26f70037c860202a0d4b"
+dependencies = [
+ "anyhow",
+ "ethereum-types",
+ "hex",
+ "sha3",
+ "thiserror",
+ "uint",
+]
+
+[[package]]
+name = "ethbloom"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfb684ac8fa8f6c5759f788862bb22ec6fe3cb392f6bfd08e3c64b603661e3f8"
+dependencies = [
+ "crunchy",
+ "fixed-hash",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "ethereum-types"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05136f7057fe789f06e6d41d07b34e6f70d8c86e5693b60f97aaa6553553bdaf"
+dependencies = [
+ "ethbloom",
+ "fixed-hash",
+ "primitive-types 0.10.0",
+ "uint",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2057,9 +2094,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -2223,9 +2260,9 @@ dependencies = [
 
 [[package]]
 name = "hex"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hex-literal"
@@ -4512,15 +4549,18 @@ dependencies = [
 name = "pallet-eth-sub-bridge"
 version = "3.0.0"
 dependencies = [
+ "ethabi",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
  "hex-literal",
+ "log",
  "node-primitives",
  "pallet-balances 3.0.0",
  "pallet-timestamp",
  "parity-scale-codec",
  "serde",
+ "serde_json",
  "sp-core",
  "sp-io",
  "sp-runtime",
@@ -5074,7 +5114,7 @@ dependencies = [
  "impl-trait-for-tuples",
  "parity-util-mem-derive",
  "parking_lot 0.11.1",
- "primitive-types",
+ "primitive-types 0.9.0",
  "smallvec 1.6.1",
  "winapi 0.3.9",
 ]
@@ -5514,6 +5554,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "primitive-types"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e90f6931e6b3051e208a449c342246cb7c786ef300789b95619f46f1dd75d9b0"
+dependencies = [
+ "fixed-hash",
+ "impl-codec",
+ "uint",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5800,7 +5851,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
 dependencies = [
- "getrandom 0.2.2",
+ "getrandom 0.2.3",
 ]
 
 [[package]]
@@ -5922,7 +5973,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
- "getrandom 0.2.2",
+ "getrandom 0.2.3",
  "redox_syscall 0.2.4",
 ]
 
@@ -7349,9 +7400,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.61"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fceb2595057b6891a4ee808f70054bd2d12f0e97f1cbb78689b59f676df325a"
+checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
 dependencies = [
  "itoa",
  "ryu",
@@ -7771,7 +7822,7 @@ dependencies = [
  "parity-scale-codec",
  "parity-util-mem",
  "parking_lot 0.11.1",
- "primitive-types",
+ "primitive-types 0.9.0",
  "rand 0.7.3",
  "regex",
  "schnorrkel",
@@ -7982,7 +8033,7 @@ source = "git+https://github.com/paritytech/substrate?tag=v3.0.0#49a4103f4bfef55
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
- "primitive-types",
+ "primitive-types 0.9.0",
  "sp-externalities",
  "sp-runtime-interface-proc-macro",
  "sp-std",
@@ -8314,7 +8365,7 @@ dependencies = [
  "futures 0.1.30",
  "futures 0.3.12",
  "futures-timer 3.0.2",
- "getrandom 0.2.2",
+ "getrandom 0.2.3",
  "js-sys",
  "kvdb-web",
  "libp2p-wasm-ext",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4566,7 +4566,6 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "substrate-prometheus-endpoint",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4566,6 +4566,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
+ "substrate-prometheus-endpoint",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4553,6 +4553,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "hex",
  "hex-literal",
  "log",
  "node-primitives",
@@ -4560,6 +4561,7 @@ dependencies = [
  "pallet-timestamp",
  "parity-scale-codec",
  "serde",
+ "serde_bytes",
  "serde_json",
  "sp-application-crypto",
  "sp-core",
@@ -7376,6 +7378,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16ae07dd2f88a366f15bd0632ba725227018c69a1c8550a927324f8eb8368bb9"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4561,6 +4561,7 @@ dependencies = [
  "parity-scale-codec",
  "serde",
  "serde_json",
+ "sp-application-crypto",
  "sp-core",
  "sp-io",
  "sp-runtime",

--- a/cli/src/service.rs
+++ b/cli/src/service.rs
@@ -22,7 +22,7 @@
 use futures::prelude::*;
 use node_executor::Executor;
 use node_primitives::Block;
-use node_runtime::{self,RuntimeApi};
+use node_runtime::{self, RuntimeApi};
 use sc_client_api::{ExecutorProvider, RemoteBackend};
 use sc_consensus_babe;
 use sc_network::{Event, NetworkService};
@@ -221,15 +221,7 @@ pub fn new_full_base(
             block_announce_validator_builder: None,
         })?;
 
-    let keystore = keystore_container.sync_keystore();
     if config.offchain_worker.enabled {
-        // sp_keystore::SyncCryptoStore::sr25519_generate_new(
-        //     &*keystore,
-        //     node_runtime::pallet_eth_sub_bridge::KEY_TYPE,
-        //     Some("//Alice"),
-        // )
-        // .expect("Creating key with account Alice should succeed.");
-
         sc_service::build_offchain_workers(
             &config,
             backend.clone(),
@@ -455,29 +447,13 @@ pub fn new_light_base(
         })?;
     network_starter.start_network();
 
-    let keystore = keystore_container.sync_keystore();
-    //if config.offchain_worker.enabled {
-
-        // keystore.write().insert_ephemeral_from_seed_by_type::<node_runtime::pallet_eth_sub_bridge::crypto::Pair>(
-        //     "//Alice", node_runtime::pallet_eth_sub_bridge::KEY_TYPE
-        // ).expect("Creating key with account Alice should succeed.");
-
-        // sp_keystore::SyncCryptoStore::sr25519_generate_new(
-        //     &*keystore,
-        //     node_runtime::pallet_eth_sub_bridge::KEY_TYPE,
-        //     Some("//Alice"),
-        // )
-        // .expect("Creating key with account Alice should succeed.");
-        // sp_keystore::SyncCryptoStore::
-		
-        sc_service::build_offchain_workers(
-            &config,
-            backend.clone(),
-            task_manager.spawn_handle(),
-            client.clone(),
-            network.clone(),
-        );
-    //}
+    sc_service::build_offchain_workers(
+        &config,
+        backend.clone(),
+        task_manager.spawn_handle(),
+        client.clone(),
+        network.clone(),
+    );
 
     let light_deps = node_rpc::LightDeps {
         remote_blockchain: backend.remote_blockchain(),

--- a/cli/src/service.rs
+++ b/cli/src/service.rs
@@ -223,12 +223,12 @@ pub fn new_full_base(
 
     let keystore = keystore_container.sync_keystore();
     if config.offchain_worker.enabled {
-        sp_keystore::SyncCryptoStore::sr25519_generate_new(
-            &*keystore,
-            node_runtime::pallet_eth_sub_bridge::KEY_TYPE,
-            Some("//Alice"),
-        )
-        .expect("Creating key with account Alice should succeed.");
+        // sp_keystore::SyncCryptoStore::sr25519_generate_new(
+        //     &*keystore,
+        //     node_runtime::pallet_eth_sub_bridge::KEY_TYPE,
+        //     Some("//Alice"),
+        // )
+        // .expect("Creating key with account Alice should succeed.");
 
         sc_service::build_offchain_workers(
             &config,
@@ -462,12 +462,13 @@ pub fn new_light_base(
         //     "//Alice", node_runtime::pallet_eth_sub_bridge::KEY_TYPE
         // ).expect("Creating key with account Alice should succeed.");
 
-        sp_keystore::SyncCryptoStore::sr25519_generate_new(
-            &*keystore,
-            node_runtime::pallet_eth_sub_bridge::KEY_TYPE,
-            Some("//Alice"),
-        )
-        .expect("Creating key with account Alice should succeed.");
+        // sp_keystore::SyncCryptoStore::sr25519_generate_new(
+        //     &*keystore,
+        //     node_runtime::pallet_eth_sub_bridge::KEY_TYPE,
+        //     Some("//Alice"),
+        // )
+        // .expect("Creating key with account Alice should succeed.");
+        // sp_keystore::SyncCryptoStore::
 		
         sc_service::build_offchain_workers(
             &config,

--- a/pallets/bridge/Cargo.toml
+++ b/pallets/bridge/Cargo.toml
@@ -7,10 +7,8 @@ license = "Unlicense"
 homepage = "https://deeper.network"
 repository = "https://github.com/deeper-chain/deeper-chain"
 description = "bridge to transfer DPR tokens between Ethereum and Deeper Chain"
-
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
-
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 frame-support = { default-features = false, git = "https://github.com/paritytech/substrate", tag = "v3.0.0"}
@@ -20,32 +18,35 @@ sp-std = {default-features = false, git = "https://github.com/paritytech/substra
 sp-io = { default-features = false, git = "https://github.com/paritytech/substrate", tag = "v3.0.0" }
 sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate", tag = "v3.0.0"}
 pallet-timestamp = {default-features = false, git = "https://github.com/paritytech/substrate", tag = "v3.0.0" }
-serde = { version = "1.0.101", optional = true, features = ["derive"] }
+serde = { version = "1.0.101", default-features = false, features = ["derive", "alloc"] }
+serde_json = { version = '1.0.67', default-features = false, features = ['alloc'] }
 pallet-balances = { version = "3.0.0", default-features = false, path = "../balances"}
 node-primitives = {version = '2.0.0', default-features = false, path = "../../primitives"}
 hex-literal = "0.3.1"
+log = "0.4.11"
+ethabi = { default-features = false,version = "15.0.0"}
+
 # Optional imports for benchmarking
 frame-benchmarking = { default-features = false, git = "https://github.com/paritytech/substrate", tag = "v3.0.0", optional = true }
 
 [dev-dependencies]
 sp-io = { git = "https://github.com/paritytech/substrate", tag = "v3.0.0" }
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", tag = "v3.0.0" }
-
 [features]
 default = ['std']
 std = [
-	'codec/std',
-	'frame-support/std',
-	'frame-system/std',
-	'sp-core/std',
-	'sp-io/std',
-	'sp-std/std',
-	'sp-runtime/std',
-	'pallet-timestamp/std',
-	'pallet-balances/std',
-	'node-primitives/std',
-	'serde',
+    'codec/std',
+    'frame-support/std',
+    'frame-system/std',
+    'sp-core/std',
+    'sp-io/std',
+    'sp-std/std',
+    'sp-runtime/std',
+    'pallet-timestamp/std',
+    'pallet-balances/std',
+    'node-primitives/std',
+    'ethabi/std',
 ]
 runtime-benchmarks = [
-	"frame-benchmarking",
+    "frame-benchmarking",
 ]

--- a/pallets/bridge/Cargo.toml
+++ b/pallets/bridge/Cargo.toml
@@ -14,6 +14,7 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 frame-support = { default-features = false, git = "https://github.com/paritytech/substrate", tag = "v3.0.0"}
 frame-system = { default-features = false, git = "https://github.com/paritytech/substrate", tag = "v3.0.0"}
 sp-core = { default-features = false, git = "https://github.com/paritytech/substrate", tag = "v3.0.0"}
+sp-application-crypto = { default-features = false, git = "https://github.com/paritytech/substrate", tag = "v3.0.0"}
 sp-std = {default-features = false, git = "https://github.com/paritytech/substrate", tag = "v3.0.0" }
 sp-io = { default-features = false, git = "https://github.com/paritytech/substrate", tag = "v3.0.0" }
 sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate", tag = "v3.0.0"}

--- a/pallets/bridge/Cargo.toml
+++ b/pallets/bridge/Cargo.toml
@@ -18,7 +18,6 @@ sp-application-crypto = { default-features = false, git = "https://github.com/pa
 sp-std = {default-features = false, git = "https://github.com/paritytech/substrate", tag = "v3.0.0" }
 sp-io = { default-features = false, git = "https://github.com/paritytech/substrate", tag = "v3.0.0" }
 sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate", tag = "v3.0.0"}
-substrate-prometheus-endpoint = { default-features = false, git = "https://github.com/paritytech/substrate", tag = "v3.0.0" }
 pallet-timestamp = {default-features = false, git = "https://github.com/paritytech/substrate", tag = "v3.0.0" }
 serde = { version = "1.0.101", default-features = false, features = ["derive", "alloc"] }
 serde_json = { version = '1.0.67', default-features = false, features = ['alloc'] }

--- a/pallets/bridge/Cargo.toml
+++ b/pallets/bridge/Cargo.toml
@@ -21,9 +21,11 @@ sp-runtime = { default-features = false, git = "https://github.com/paritytech/su
 pallet-timestamp = {default-features = false, git = "https://github.com/paritytech/substrate", tag = "v3.0.0" }
 serde = { version = "1.0.101", default-features = false, features = ["derive", "alloc"] }
 serde_json = { version = '1.0.67', default-features = false, features = ['alloc'] }
+serde_bytes = { version = '0.11', default-features = false, features = ['alloc'] }
 pallet-balances = { version = "3.0.0", default-features = false, path = "../balances"}
 node-primitives = {version = '2.0.0', default-features = false, path = "../../primitives"}
 hex-literal = "0.3.1"
+hex = { version = "0.4", default-features = false }
 log = "0.4.11"
 ethabi = { default-features = false,version = "15.0.0"}
 

--- a/pallets/bridge/Cargo.toml
+++ b/pallets/bridge/Cargo.toml
@@ -18,6 +18,7 @@ sp-application-crypto = { default-features = false, git = "https://github.com/pa
 sp-std = {default-features = false, git = "https://github.com/paritytech/substrate", tag = "v3.0.0" }
 sp-io = { default-features = false, git = "https://github.com/paritytech/substrate", tag = "v3.0.0" }
 sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate", tag = "v3.0.0"}
+substrate-prometheus-endpoint = { default-features = false, git = "https://github.com/paritytech/substrate", tag = "v3.0.0" }
 pallet-timestamp = {default-features = false, git = "https://github.com/paritytech/substrate", tag = "v3.0.0" }
 serde = { version = "1.0.101", default-features = false, features = ["derive", "alloc"] }
 serde_json = { version = '1.0.67', default-features = false, features = ['alloc'] }

--- a/pallets/bridge/src/benchmarking.rs
+++ b/pallets/bridge/src/benchmarking.rs
@@ -23,15 +23,12 @@ use codec::Encode;
 pub use frame_benchmarking::{account, benchmarks, whitelist_account, whitelisted_caller};
 use frame_support::traits::Currency;
 use frame_system::RawOrigin;
-use hex_literal::hex;
 pub use node_primitives::{AccountId, Signature};
 use sp_core::{sr25519, Hasher, H160};
 use sp_io::crypto::{sr25519_generate, sr25519_sign};
-use sp_runtime::traits::{IdentifyAccount, Verify};
 use sp_runtime::{MultiSignature, MultiSigner};
 use sp_std::{convert::TryFrom, vec::Vec};
 use types::Status;
-type AccountPublic = <Signature as Verify>::Signer;
 
 const SEED: u32 = 0;
 const USER_SEED: u32 = 999666;

--- a/pallets/bridge/src/ethereum.rs
+++ b/pallets/bridge/src/ethereum.rs
@@ -40,3 +40,9 @@ fn test_decode_data() {
         amount: 20000000000000000000000,
     }, decode_data(&hex!("3b63ad0b9c134cc87a287b22e17ab6475553edeed90096c93e2c73ed58f49114000000000000000000000000a56403cd96695f590638ba1af16a37f12d26f1f20e6409835f9b350d57feaa750d1396a5493e2537bd72e908e2e24ce95de47e3d00000000000000000000000000000000000000000000043c33c1937564800000")));
 }
+
+#[test]
+fn test_deserilize() {
+    let s = r#"{"jsonrpc":"2.0","id":1,"result":"0x10ff0e058a85e8b479fa3214d856f96b22fb9c28679a"}"#;
+    let info: super::CreateNewFilterResp = serde_json::from_slice(s.as_bytes()).unwrap();
+}

--- a/pallets/bridge/src/ethereum.rs
+++ b/pallets/bridge/src/ethereum.rs
@@ -51,9 +51,9 @@ pub trait Client {
 }
 
 #[derive(Default)]
-pub struct DefaultEthClient;
+pub struct MockEthClient;
 
-impl Client for DefaultEthClient {
+impl Client for MockEthClient {
     fn get_eth_logs(&self) -> Result<(Vec<SetTransferData>, Vec<u8>), Error> {
         Ok((vec![SetTransferData::default()], "abc".as_bytes().to_vec()))
     }

--- a/pallets/bridge/src/ethereum.rs
+++ b/pallets/bridge/src/ethereum.rs
@@ -1,10 +1,11 @@
-use core::convert::TryInto;
 use codec::{Decode, Encode};
+use core::convert::TryInto;
 use serde::{Deserialize, Serialize};
-use sp_std::vec::Vec;
+use sp_runtime::offchain::{http, Duration};
+use sp_std::prelude::*;
+use sp_std::str;
 use sp_std::vec;
-
-// pub type Result<T> = std::result::Result<T, Error>;
+use sp_std::vec::Vec;
 
 /// Errors that can occur only when interacting with
 /// an Ethereum node through RPC.
@@ -42,22 +43,172 @@ pub struct EthLog {
 pub struct SetTransferData {
     pub message_id: Vec<u8>, // H256, bytes32
     pub sender: Vec<u8>,     // H160, Bytes20
-    pub recipient: [u8; 32],  // H256, bytes32
+    pub recipient: [u8; 32], // H256, bytes32
     pub amount: u128,
 }
 
 pub trait Client {
-    fn get_eth_logs(&self) -> Result<(Vec<SetTransferData>, Vec<u8>), Error>;
+    fn get_eth_logs(filter_id: Vec<u8>) -> Result<(Vec<SetTransferData>, Vec<u8>), Error>;
 }
 
+// A mock eth client for test, in the future should use a real client
 #[derive(Default)]
 pub struct MockEthClient;
 
 impl Client for MockEthClient {
-    fn get_eth_logs(&self) -> Result<(Vec<SetTransferData>, Vec<u8>), Error> {
-        Ok((vec![SetTransferData::default()], "abc".as_bytes().to_vec()))
+    fn get_eth_logs(filter_id: Vec<u8>) -> Result<(Vec<SetTransferData>, Vec<u8>), Error> {
+        Ok((vec![SetTransferData::default()], filter_id))
     }
 }
+
+#[derive(Default)]
+pub struct RealEthClient;
+
+impl Client for RealEthClient {
+    fn get_eth_logs(mut filter_id: Vec<u8>) -> Result<(Vec<SetTransferData>, Vec<u8>), Error> {
+        if filter_id.is_empty() {
+            filter_id = Self::create_eth_filter_id_n_parse()?;
+        }
+        log::info!("before get_eth_logs_n_parse: {:?}", filter_id);
+        let logs = Self::get_eth_logs_n_parse(filter_id.clone())?;
+        Ok((logs, filter_id))
+    }
+}
+
+const HTTP_REMOTE_REQUEST: &str = "https://mainnet.infura.io/v3/75284d8d0fb14ab88520b949270fe205";
+const FETCH_TIMEOUT_PERIOD: u64 = 3000; // in milli-seconds
+
+impl RealEthClient {
+    fn get_eth_logs_n_parse(filter_id: Vec<u8>) -> Result<Vec<SetTransferData>, Error> {
+        let resp_bytes = Self::get_eth_logs_from_remote(filter_id).map_err(|e| {
+            log::error!("fetch_from_remote error: {:?}", e);
+            Error::Network
+        })?;
+
+        let resp_str = str::from_utf8(&resp_bytes).map_err(|_| Error::Network)?;
+        log::info!("get_eth_logs_n_parse: {}", resp_str);
+
+        // Deserializing JSON to struct, thanks to `serde` and `serde_derive`
+        let info: GetLogsResp = serde_json::from_str(&resp_str).map_err(|_| Error::Network)?;
+        let data: Vec<SetTransferData> = info.result.iter().map(|d| decode_data(&d.data)).collect();
+        Ok(data)
+    }
+
+    fn get_eth_logs_from_remote(mut filter_id: Vec<u8>) -> Result<Vec<u8>, Error> {
+        let mut body_bytes =
+            "{\"jsonrpc\":\"2.0\",\"method\":\"eth_getFilterChanges\",\"params\":[\""
+                .as_bytes()
+                .to_vec();
+        body_bytes.append(&mut filter_id);
+        body_bytes.append(&mut "\"],\"id\":1}".as_bytes().to_vec());
+        let body_str = str::from_utf8(&body_bytes).unwrap();
+        let body = vec![body_str];
+        log::info!("get_eth_logs_from_remote: {:?}", body);
+
+        let request = http::Request::post(HTTP_REMOTE_REQUEST, body);
+
+        // Keeping the offchain worker execution time reasonable, so limiting the call to be within 3s.
+        let timeout = sp_io::offchain::timestamp().add(Duration::from_millis(FETCH_TIMEOUT_PERIOD));
+
+        let pending = request
+            .add_header("Content-Type", "application/json")
+            .deadline(timeout) // Setting the timeout time
+            .send() // Sending the request out by the host
+            .map_err(|e| {
+                log::error!("{:?}", e);
+                Error::Network
+            })?;
+
+        let response = pending
+            .try_wait(timeout)
+            .map_err(|e| {
+                log::error!("{:?}", e);
+                Error::Network
+            })?
+            .map_err(|e| {
+                log::error!("{:?}", e);
+                Error::Network
+            })?;
+
+        if response.code != 200 {
+            log::error!("Unexpected http request status code: {}", response.code);
+            return Err(Error::Network);
+        }
+
+        // Next we fully read the response body and collect it to a vector of bytes.
+        Ok(response.body().collect::<Vec<u8>>())
+    }
+
+    fn create_eth_filter_id_from_remote() -> Result<Vec<u8>, Error> {
+        let body = vec![
+            r#"{"jsonrpc":"2.0","method":"eth_newFilter","params":[{"topics": ["0xfb65d1544ea97e32c62baf55f738f7bb44671998c927415ef03e52d2477e292f"]}],"id":1}"#,
+        ];
+        let request = http::Request::post(HTTP_REMOTE_REQUEST, body);
+
+        // Keeping the offchain worker execution time reasonable, so limiting the call to be within 3s.
+        let timeout = sp_io::offchain::timestamp().add(Duration::from_millis(FETCH_TIMEOUT_PERIOD));
+
+        let pending = request
+            .add_header("Content-Type", "application/json")
+            .deadline(timeout) // Setting the timeout time
+            .send() // Sending the request out by the host
+            .map_err(|e| {
+                log::error!("{:?}", e);
+                Error::Network
+            })?;
+
+        // By default, the http request is async from the runtime perspective. So we are asking the
+        //   runtime to wait here
+        // The returning value here is a `Result` of `Result`, so we are unwrapping it twice by two `?`
+        //   ref: https://docs.substrate.io/rustdocs/latest/sp_runtime/offchain/http/struct.PendingRequest.html#method.try_wait
+        let response = pending
+            .try_wait(timeout)
+            .map_err(|e| {
+                log::error!("{:?}", e);
+                Error::Network
+            })?
+            .map_err(|e| {
+                log::error!("{:?}", e);
+                Error::Network
+            })?;
+
+        if response.code != 200 {
+            log::error!("Unexpected http request status code: {}", response.code);
+            return Err(Error::Network);
+        }
+
+        // Next we fully read the response body and collect it to a vector of bytes.
+        Ok(response.body().collect::<Vec<u8>>())
+    }
+    fn create_eth_filter_id_n_parse() -> Result<Vec<u8>, Error> {
+        let resp_bytes = Self::create_eth_filter_id_from_remote().map_err(|e| {
+            log::error!("create_new_filter_id_n_parse error: {:?}", e);
+            Error::Network
+        })?;
+
+        let resp_str = str::from_utf8(&resp_bytes).map_err(|_| Error::Network)?;
+        log::info!("create_new_filter_id_n_parse: {}", resp_str);
+
+        let filter_id = parse_new_eth_filter_response(resp_str);
+        if !filter_id.is_empty() {
+            return Ok(filter_id);
+        }
+        Err(Error::Network)
+    }
+}
+
+// parse response of new_filter into a struct is hard in no_std, so use a
+// string matching to get the filter_id
+pub fn parse_new_eth_filter_response(resp_str: &str) -> Vec<u8> {
+    if let Some(pos) = resp_str.find("result") {
+        let start = pos + 9;
+        let end = start + 46;
+        let result = &resp_str[start..end];
+        return result.as_bytes().to_vec();
+    }
+    vec![]
+}
+
 pub fn decode_data(data: &[u8]) -> SetTransferData {
     let decoded_data = ethabi::decode(
         &[
@@ -77,7 +228,12 @@ pub fn decode_data(data: &[u8]) -> SetTransferData {
             .unwrap()
             .as_bytes()
             .to_vec(),
-        recipient: decoded_data[2].clone().into_fixed_bytes().unwrap().try_into().unwrap(),
+        recipient: decoded_data[2]
+            .clone()
+            .into_fixed_bytes()
+            .unwrap()
+            .try_into()
+            .unwrap(),
         amount: decoded_data[3].clone().into_uint().unwrap().low_u128(),
     }
 }
@@ -97,7 +253,7 @@ fn test_decode_data() {
 #[test]
 fn test_deserilize() {
     let s = r#"{"jsonrpc":"2.0","id":1,"result":"0x10ff0e058a85e8b479fa3214d856f96b22fb9c28679a"}"#;
-    let filter_id = crate::pallet::parse_new_eth_filter_response(s);
+    let filter_id = crate::ethereum::parse_new_eth_filter_response(s);
     assert_eq!(
         "0x10ff0e058a85e8b479fa3214d856f96b22fb9c28679a"
             .as_bytes()

--- a/pallets/bridge/src/ethereum.rs
+++ b/pallets/bridge/src/ethereum.rs
@@ -1,0 +1,42 @@
+use codec::{Decode, Encode};
+use serde::{Deserialize, Serialize};
+use sp_std::vec::Vec;
+
+#[derive(Serialize, Deserialize, Debug, Encode, Decode, Clone, PartialEq, Eq)]
+pub struct SetTransferData {
+    pub message_id: Vec<u8>, // bytes32
+    // pub sender: Vec<u8>, // TODO: fix why can't just use FixedBytes(20)
+    pub recipient: Vec<u8>, // bytes32
+    pub amount: u128,
+}
+
+pub fn decode_data(data: &[u8]) -> SetTransferData {
+    let decode_input = ethabi::decode(
+        &[
+            ethabi::ParamType::FixedBytes(32),
+            ethabi::ParamType::FixedBytes(20),
+            ethabi::ParamType::FixedBytes(32),
+            ethabi::ParamType::Uint(128),
+        ],
+        data,
+    )
+    .unwrap();
+    SetTransferData {
+        message_id: decode_input[0].clone().into_fixed_bytes().unwrap(),
+        // sender: decode_input[1].clone().into_fixed_bytes().unwrap(),
+        recipient: decode_input[2].clone().into_fixed_bytes().unwrap(),
+        amount: decode_input[3].clone().into_uint().unwrap().low_u128(),
+    }
+}
+
+#[test]
+fn test_decode_data() {
+    use hex_literal::hex;
+    // https://etherscan.io/tx/0x125906f92d35cf1b9586ced5557b8ce646e88353cdfe04336a546b8197a4c04a#eventlog
+    assert_eq!(SetTransferData{
+        message_id: hex!("3B63AD0B9C134CC87A287B22E17AB6475553EDEED90096C93E2C73ED58F49114").to_vec(),
+        // sender: hex!("a56403cd96695f590638ba1af16a37f12d26f1f2").to_vec(),
+        recipient: hex!("0E6409835F9B350D57FEAA750D1396A5493E2537BD72E908E2E24CE95DE47E3D").to_vec(),
+        amount: 20000000000000000000000,
+    }, decode_data(&hex!("3b63ad0b9c134cc87a287b22e17ab6475553edeed90096c93e2c73ed58f49114000000000000000000000000a56403cd96695f590638ba1af16a37f12d26f1f20e6409835f9b350d57feaa750d1396a5493e2537bd72e908e2e24ce95de47e3d00000000000000000000000000000000000000000000043c33c1937564800000")));
+}

--- a/pallets/bridge/src/ethereum.rs
+++ b/pallets/bridge/src/ethereum.rs
@@ -1,3 +1,4 @@
+use core::convert::TryInto;
 use codec::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use sp_std::vec::Vec;
@@ -41,7 +42,7 @@ pub struct EthLog {
 pub struct SetTransferData {
     pub message_id: Vec<u8>, // H256, bytes32
     pub sender: Vec<u8>,     // H160, Bytes20
-    pub recipient: Vec<u8>,  // H256, bytes32
+    pub recipient: [u8; 32],  // H256, bytes32
     pub amount: u128,
 }
 
@@ -76,7 +77,7 @@ pub fn decode_data(data: &[u8]) -> SetTransferData {
             .unwrap()
             .as_bytes()
             .to_vec(),
-        recipient: decoded_data[2].clone().into_fixed_bytes().unwrap(),
+        recipient: decoded_data[2].clone().into_fixed_bytes().unwrap().try_into().unwrap(),
         amount: decoded_data[3].clone().into_uint().unwrap().low_u128(),
     }
 }
@@ -88,7 +89,7 @@ fn test_decode_data() {
     assert_eq!(SetTransferData{
         message_id: hex!("3B63AD0B9C134CC87A287B22E17AB6475553EDEED90096C93E2C73ED58F49114").to_vec(),
         sender: hex!("a56403cd96695f590638ba1af16a37f12d26f1f2").to_vec(),
-        recipient: hex!("0E6409835F9B350D57FEAA750D1396A5493E2537BD72E908E2E24CE95DE47E3D").to_vec(),
+        recipient: hex!("0E6409835F9B350D57FEAA750D1396A5493E2537BD72E908E2E24CE95DE47E3D").to_vec().try_into().unwrap(),
         amount: 20000000000000000000000,
     }, decode_data(&hex!("3b63ad0b9c134cc87a287b22e17ab6475553edeed90096c93e2c73ed58f49114000000000000000000000000a56403cd96695f590638ba1af16a37f12d26f1f20e6409835f9b350d57feaa750d1396a5493e2537bd72e908e2e24ce95de47e3d00000000000000000000000000000000000000000000043c33c1937564800000")));
 }

--- a/pallets/bridge/src/ethereum.rs
+++ b/pallets/bridge/src/ethereum.rs
@@ -2,19 +2,19 @@ use codec::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use sp_std::vec::Vec;
 
-#[derive(Serialize, Deserialize, Debug, Encode, Decode, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Encode, Decode, Clone, PartialEq, Eq, Default)]
 pub struct SetTransferData {
-    pub message_id: Vec<u8>, // bytes32
-    // pub sender: Vec<u8>, // TODO: fix why can't just use FixedBytes(20)
-    pub recipient: Vec<u8>, // bytes32
+    pub message_id: Vec<u8>, // H256, bytes32
+    pub sender: Vec<u8>,     // H160, Bytes20
+    pub recipient: Vec<u8>,  // H256, bytes32
     pub amount: u128,
 }
 
 pub fn decode_data(data: &[u8]) -> SetTransferData {
-    let decode_input = ethabi::decode(
+    let decoded_data = ethabi::decode(
         &[
             ethabi::ParamType::FixedBytes(32),
-            ethabi::ParamType::FixedBytes(20),
+            ethabi::ParamType::Address,
             ethabi::ParamType::FixedBytes(32),
             ethabi::ParamType::Uint(128),
         ],
@@ -22,10 +22,15 @@ pub fn decode_data(data: &[u8]) -> SetTransferData {
     )
     .unwrap();
     SetTransferData {
-        message_id: decode_input[0].clone().into_fixed_bytes().unwrap(),
-        // sender: decode_input[1].clone().into_fixed_bytes().unwrap(),
-        recipient: decode_input[2].clone().into_fixed_bytes().unwrap(),
-        amount: decode_input[3].clone().into_uint().unwrap().low_u128(),
+        message_id: decoded_data[0].clone().into_fixed_bytes().unwrap(),
+        sender: decoded_data[1]
+            .clone()
+            .into_address()
+            .unwrap()
+            .as_bytes()
+            .to_vec(),
+        recipient: decoded_data[2].clone().into_fixed_bytes().unwrap(),
+        amount: decoded_data[3].clone().into_uint().unwrap().low_u128(),
     }
 }
 
@@ -35,7 +40,7 @@ fn test_decode_data() {
     // https://etherscan.io/tx/0x125906f92d35cf1b9586ced5557b8ce646e88353cdfe04336a546b8197a4c04a#eventlog
     assert_eq!(SetTransferData{
         message_id: hex!("3B63AD0B9C134CC87A287B22E17AB6475553EDEED90096C93E2C73ED58F49114").to_vec(),
-        // sender: hex!("a56403cd96695f590638ba1af16a37f12d26f1f2").to_vec(),
+        sender: hex!("a56403cd96695f590638ba1af16a37f12d26f1f2").to_vec(),
         recipient: hex!("0E6409835F9B350D57FEAA750D1396A5493E2537BD72E908E2E24CE95DE47E3D").to_vec(),
         amount: 20000000000000000000000,
     }, decode_data(&hex!("3b63ad0b9c134cc87a287b22e17ab6475553edeed90096c93e2c73ed58f49114000000000000000000000000a56403cd96695f590638ba1af16a37f12d26f1f20e6409835f9b350d57feaa750d1396a5493e2537bd72e908e2e24ce95de47e3d00000000000000000000000000000000000000000000043c33c1937564800000")));
@@ -44,5 +49,11 @@ fn test_decode_data() {
 #[test]
 fn test_deserilize() {
     let s = r#"{"jsonrpc":"2.0","id":1,"result":"0x10ff0e058a85e8b479fa3214d856f96b22fb9c28679a"}"#;
-    let info: super::CreateNewFilterResp = serde_json::from_slice(s.as_bytes()).unwrap();
+    let filter_id = crate::pallet::parse_new_eth_filter_response(s);
+    assert_eq!(
+        "0x10ff0e058a85e8b479fa3214d856f96b22fb9c28679a"
+            .as_bytes()
+            .to_vec(),
+        filter_id
+    );
 }

--- a/pallets/bridge/src/ethereum.rs
+++ b/pallets/bridge/src/ethereum.rs
@@ -1,6 +1,41 @@
 use codec::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use sp_std::vec::Vec;
+use sp_std::vec;
+
+// pub type Result<T> = std::result::Result<T, Error>;
+
+/// Errors that can occur only when interacting with
+/// an Ethereum node through RPC.
+#[derive(Debug)]
+pub enum Error {
+    Network,
+}
+
+#[derive(Serialize, Deserialize, Debug, Default, Encode, Decode, Clone)]
+pub struct GetLogsResp {
+    pub result: Vec<EthLog>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Default, Encode, Decode, Clone)]
+pub struct EthLog {
+    pub address: Vec<u8>,
+
+    #[serde(rename = "blockHash")]
+    pub block_hash: Vec<u8>,
+
+    #[serde(rename = "blockNumber")]
+    pub block_number: Vec<u8>,
+
+    pub data: Vec<u8>,
+
+    pub removed: bool,
+
+    pub topics: Vec<Vec<u8>>,
+
+    #[serde(rename = "transactionHash")]
+    pub transaction_hash: Vec<u8>,
+}
 
 #[derive(Serialize, Deserialize, Debug, Encode, Decode, Clone, PartialEq, Eq, Default)]
 pub struct SetTransferData {
@@ -10,6 +45,18 @@ pub struct SetTransferData {
     pub amount: u128,
 }
 
+pub trait Client {
+    fn get_eth_logs(&self) -> Result<(Vec<SetTransferData>, Vec<u8>), Error>;
+}
+
+#[derive(Default)]
+pub struct DefaultEthClient;
+
+impl Client for DefaultEthClient {
+    fn get_eth_logs(&self) -> Result<(Vec<SetTransferData>, Vec<u8>), Error> {
+        Ok((vec![SetTransferData::default()], "abc".as_bytes().to_vec()))
+    }
+}
 pub fn decode_data(data: &[u8]) -> SetTransferData {
     let decoded_data = ethabi::decode(
         &[

--- a/pallets/bridge/src/ethereum.rs
+++ b/pallets/bridge/src/ethereum.rs
@@ -75,7 +75,7 @@ impl Client for RealEthClient {
     }
 }
 
-const HTTP_REMOTE_REQUEST: &str = "https://mainnet.infura.io/v3/75284d8d0fb14ab88520b949270fe205";
+pub const HTTP_REMOTE_REQUEST: &str = "https://kovan.infura.io/v3/bd22e70259d546dd832b63b7cab12ed0";
 const FETCH_TIMEOUT_PERIOD: u64 = 3000; // in milli-seconds
 
 impl RealEthClient {

--- a/pallets/bridge/src/ethereum.rs
+++ b/pallets/bridge/src/ethereum.rs
@@ -21,22 +21,15 @@ pub struct GetLogsResp {
 
 #[derive(Serialize, Deserialize, Debug, Default, Encode, Decode, Clone)]
 pub struct EthLog {
+    #[serde(with = "serde_bytes")]
     pub address: Vec<u8>,
 
-    #[serde(rename = "blockHash")]
-    pub block_hash: Vec<u8>,
-
     #[serde(rename = "blockNumber")]
+    #[serde(with = "serde_bytes")]
     pub block_number: Vec<u8>,
 
+    #[serde(with = "serde_bytes")]
     pub data: Vec<u8>,
-
-    pub removed: bool,
-
-    pub topics: Vec<Vec<u8>>,
-
-    #[serde(rename = "transactionHash")]
-    pub transaction_hash: Vec<u8>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Encode, Decode, Clone, PartialEq, Eq, Default)]
@@ -48,7 +41,7 @@ pub struct SetTransferData {
 }
 
 pub trait Client {
-    fn get_eth_logs(filter_id: Vec<u8>) -> Result<(Vec<SetTransferData>, Vec<u8>), Error>;
+    fn get_eth_logs(from_block_hash: Vec<u8>) -> Result<(Vec<SetTransferData>, Vec<u8>), Error>;
 }
 
 // A mock eth client for test, in the future should use a real client
@@ -56,8 +49,8 @@ pub trait Client {
 pub struct MockEthClient;
 
 impl Client for MockEthClient {
-    fn get_eth_logs(filter_id: Vec<u8>) -> Result<(Vec<SetTransferData>, Vec<u8>), Error> {
-        Ok((vec![SetTransferData::default()], filter_id))
+    fn get_eth_logs(from_block_hash: Vec<u8>) -> Result<(Vec<SetTransferData>, Vec<u8>), Error> {
+        Ok((vec![SetTransferData::default()], from_block_hash))
     }
 }
 
@@ -65,13 +58,14 @@ impl Client for MockEthClient {
 pub struct RealEthClient;
 
 impl Client for RealEthClient {
-    fn get_eth_logs(mut filter_id: Vec<u8>) -> Result<(Vec<SetTransferData>, Vec<u8>), Error> {
-        if filter_id.is_empty() {
-            filter_id = Self::create_eth_filter_id_n_parse()?;
+    fn get_eth_logs(
+        mut from_block_number: Vec<u8>,
+    ) -> Result<(Vec<SetTransferData>, Vec<u8>), Error> {
+        if from_block_number.is_empty() {
+            from_block_number = "earliest".as_bytes().to_vec();
         }
-        log::info!("before get_eth_logs_n_parse: {:?}", filter_id);
-        let logs = Self::get_eth_logs_n_parse(filter_id.clone())?;
-        Ok((logs, filter_id))
+        let (logs, from_block_number) = Self::get_eth_logs_n_parse(from_block_number.clone())?;
+        Ok((logs, from_block_number))
     }
 }
 
@@ -79,30 +73,57 @@ pub const HTTP_REMOTE_REQUEST: &str = "https://kovan.infura.io/v3/bd22e70259d546
 const FETCH_TIMEOUT_PERIOD: u64 = 3000; // in milli-seconds
 
 impl RealEthClient {
-    fn get_eth_logs_n_parse(filter_id: Vec<u8>) -> Result<Vec<SetTransferData>, Error> {
-        let resp_bytes = Self::get_eth_logs_from_remote(filter_id).map_err(|e| {
-            log::error!("fetch_from_remote error: {:?}", e);
-            Error::Network
-        })?;
+    fn get_eth_logs_n_parse(
+        mut from_block_number: Vec<u8>,
+    ) -> Result<(Vec<SetTransferData>, Vec<u8>), Error> {
+        let resp_bytes =
+            Self::get_eth_logs_from_remote(from_block_number.clone()).map_err(|e| {
+                log::error!("fetch_from_remote error: {:?}", e);
+                Error::Network
+            })?;
 
         let resp_str = str::from_utf8(&resp_bytes).map_err(|_| Error::Network)?;
-        log::info!("get_eth_logs_n_parse: {}", resp_str);
+        log::info!("get_eth_logs_from_remote: {}", resp_str);
 
         // Deserializing JSON to struct, thanks to `serde` and `serde_derive`
-        let info: GetLogsResp = serde_json::from_str(&resp_str).map_err(|_| Error::Network)?;
+        let info: GetLogsResp = serde_json::from_str(&resp_str).map_err(|e| {
+            log::error!("deserialize_err, {:?}", e);
+            Error::Network
+        })?;
         let data: Vec<SetTransferData> = info.result.iter().map(|d| decode_data(&d.data)).collect();
-        Ok(data)
+        if let Some(last_block) = info.result.iter().last() {
+            from_block_number = last_block.block_number.clone();
+        }
+        log::info!("get_eth_logs_n_parse: {:?}, {:?}", data, from_block_number);
+
+        Ok((data, from_block_number))
     }
 
-    fn get_eth_logs_from_remote(mut filter_id: Vec<u8>) -> Result<Vec<u8>, Error> {
-        let mut body_bytes =
-            "{\"jsonrpc\":\"2.0\",\"method\":\"eth_getFilterChanges\",\"params\":[\""
-                .as_bytes()
-                .to_vec();
-        body_bytes.append(&mut filter_id);
-        body_bytes.append(&mut "\"],\"id\":1}".as_bytes().to_vec());
-        let body_str = str::from_utf8(&body_bytes).unwrap();
-        let body = vec![body_str];
+    fn get_eth_logs_from_remote(from_block_number: Vec<u8>) -> Result<Vec<u8>, Error> {
+        let address = "0x309ed2c169decb81c5969dc9667aa7919170b6bd";
+        let body_str = r#"
+        {
+            "jsonrpc": "2.0",
+            "method": "eth_getLogs",
+            "params": [
+                {
+                    "address": "ETH_GETLOGS_ADDRESS",
+                    "topics": [
+                        "0xfb65d1544ea97e32c62baf55f738f7bb44671998c927415ef03e52d2477e292f"
+                    ],
+                    "fromBlock": "ETH_GETLOGS_FROM_BLOCK_NUMBER",
+                    "toBlock": "latest"
+                }
+            ],
+            "id": 1
+        }"#;
+        let body_str = body_str.replace(
+            "ETH_GETLOGS_FROM_BLOCK_NUMBER",
+            str::from_utf8(&from_block_number).unwrap(),
+        );
+        let body_str = body_str.replace("ETH_GETLOGS_ADDRESS", address);
+
+        let body = vec![body_str.as_str()];
         log::info!("get_eth_logs_from_remote: {:?}", body);
 
         let request = http::Request::post(HTTP_REMOTE_REQUEST, body);
@@ -138,63 +159,6 @@ impl RealEthClient {
         // Next we fully read the response body and collect it to a vector of bytes.
         Ok(response.body().collect::<Vec<u8>>())
     }
-
-    fn create_eth_filter_id_from_remote() -> Result<Vec<u8>, Error> {
-        let body = vec![
-            r#"{"jsonrpc":"2.0","method":"eth_newFilter","params":[{"topics": ["0xfb65d1544ea97e32c62baf55f738f7bb44671998c927415ef03e52d2477e292f"]}],"id":1}"#,
-        ];
-        let request = http::Request::post(HTTP_REMOTE_REQUEST, body);
-
-        // Keeping the offchain worker execution time reasonable, so limiting the call to be within 3s.
-        let timeout = sp_io::offchain::timestamp().add(Duration::from_millis(FETCH_TIMEOUT_PERIOD));
-
-        let pending = request
-            .add_header("Content-Type", "application/json")
-            .deadline(timeout) // Setting the timeout time
-            .send() // Sending the request out by the host
-            .map_err(|e| {
-                log::error!("{:?}", e);
-                Error::Network
-            })?;
-
-        // By default, the http request is async from the runtime perspective. So we are asking the
-        //   runtime to wait here
-        // The returning value here is a `Result` of `Result`, so we are unwrapping it twice by two `?`
-        //   ref: https://docs.substrate.io/rustdocs/latest/sp_runtime/offchain/http/struct.PendingRequest.html#method.try_wait
-        let response = pending
-            .try_wait(timeout)
-            .map_err(|e| {
-                log::error!("{:?}", e);
-                Error::Network
-            })?
-            .map_err(|e| {
-                log::error!("{:?}", e);
-                Error::Network
-            })?;
-
-        if response.code != 200 {
-            log::error!("Unexpected http request status code: {}", response.code);
-            return Err(Error::Network);
-        }
-
-        // Next we fully read the response body and collect it to a vector of bytes.
-        Ok(response.body().collect::<Vec<u8>>())
-    }
-    fn create_eth_filter_id_n_parse() -> Result<Vec<u8>, Error> {
-        let resp_bytes = Self::create_eth_filter_id_from_remote().map_err(|e| {
-            log::error!("create_new_filter_id_n_parse error: {:?}", e);
-            Error::Network
-        })?;
-
-        let resp_str = str::from_utf8(&resp_bytes).map_err(|_| Error::Network)?;
-        log::info!("create_new_filter_id_n_parse: {}", resp_str);
-
-        let filter_id = parse_new_eth_filter_response(resp_str);
-        if !filter_id.is_empty() {
-            return Ok(filter_id);
-        }
-        Err(Error::Network)
-    }
 }
 
 // parse response of new_filter into a struct is hard in no_std, so use a
@@ -210,6 +174,11 @@ pub fn parse_new_eth_filter_response(resp_str: &str) -> Vec<u8> {
 }
 
 pub fn decode_data(data: &[u8]) -> SetTransferData {
+    let mut origin_str = str::from_utf8(data).unwrap();
+    if origin_str.starts_with("0x") {
+        origin_str = &origin_str[2..];
+    }
+    let data_arr = hex::decode(origin_str).unwrap();
     let decoded_data = ethabi::decode(
         &[
             ethabi::ParamType::FixedBytes(32),
@@ -217,7 +186,7 @@ pub fn decode_data(data: &[u8]) -> SetTransferData {
             ethabi::ParamType::FixedBytes(32),
             ethabi::ParamType::Uint(128),
         ],
-        data,
+        &data_arr,
     )
     .unwrap();
     SetTransferData {
@@ -247,7 +216,15 @@ fn test_decode_data() {
         sender: hex!("a56403cd96695f590638ba1af16a37f12d26f1f2").to_vec(),
         recipient: hex!("0E6409835F9B350D57FEAA750D1396A5493E2537BD72E908E2E24CE95DE47E3D").to_vec().try_into().unwrap(),
         amount: 20000000000000000000000,
-    }, decode_data(&hex!("3b63ad0b9c134cc87a287b22e17ab6475553edeed90096c93e2c73ed58f49114000000000000000000000000a56403cd96695f590638ba1af16a37f12d26f1f20e6409835f9b350d57feaa750d1396a5493e2537bd72e908e2e24ce95de47e3d00000000000000000000000000000000000000000000043c33c1937564800000")));
+    }, decode_data("0x3b63ad0b9c134cc87a287b22e17ab6475553edeed90096c93e2c73ed58f49114000000000000000000000000a56403cd96695f590638ba1af16a37f12d26f1f20e6409835f9b350d57feaa750d1396a5493e2537bd72e908e2e24ce95de47e3d00000000000000000000000000000000000000000000043c33c1937564800000".as_bytes()));
+
+    // https://kovan.etherscan.io/tx/0xbf7709e510376ccc969562b8fa3d2bfbfed5093c35143e81f9b2780147731c41#eventlog
+    assert_eq!(SetTransferData {
+        message_id: hex!("80C4241D9D0C28C6D647DE0DD7D4099E32C5B4114EA9C4C74EFBC3C2C317C3EC").to_vec(),
+        sender: hex!("720ac46fdb6da28fa751bc60afb8094290c2b4b7").to_vec(),
+        recipient: hex!("C2F9A45E09CF0943E8A9CED81426842CCB640A55BD54E3A3D5F6186C5F584216").to_vec().try_into().unwrap(),
+        amount: 1000000000000000000000,
+    }, decode_data("0x80c4241d9d0c28c6d647de0dd7d4099e32c5b4114ea9c4c74efbc3c2c317c3ec000000000000000000000000720ac46fdb6da28fa751bc60afb8094290c2b4b7c2f9a45e09cf0943e8a9ced81426842ccb640a55bd54e3a3d5f6186c5f58421600000000000000000000000000000000000000000000003635c9adc5dea00000".as_bytes()))
 }
 
 #[test]

--- a/pallets/bridge/src/lib.rs
+++ b/pallets/bridge/src/lib.rs
@@ -11,7 +11,7 @@ mod mock;
 #[cfg(test)]
 mod tests;
 
-mod ethereum;
+pub mod ethereum;
 mod types;
 
 #[cfg(any(feature = "runtime-benchmarks", test))]
@@ -129,6 +129,7 @@ pub mod pallet {
         type WeightInfo: WeightInfo;
         type Call: From<Call<Self>>;
         type AuthorityId: AppCrypto<Self::Public, Self::Signature>;
+        type EthClient: ethereum::Client;
     }
 
     #[pallet::pallet]
@@ -346,9 +347,7 @@ pub mod pallet {
         fn offchain_worker(block_number: T::BlockNumber) {
             // sync eth->dpr transactions every 100 blocks
             if block_number % 2u32.into() == Zero::zero() {
-                // let (logs, filter_id) = Self::get_eth_logs().unwrap();
-                let client = ethereum::DefaultEthClient::default();
-                let (logs, filter_id) = client.get_eth_logs().unwrap();
+                let (logs, filter_id) = Self::get_eth_logs().unwrap();
                 let signer = Signer::<T, T::AuthorityId>::any_account();
                 if !signer.can_sign() {
                     log::error!(

--- a/pallets/bridge/src/lib.rs
+++ b/pallets/bridge/src/lib.rs
@@ -322,7 +322,7 @@ pub mod pallet {
                 // let (logs, filter_id) = Self::get_eth_logs().unwrap();
                 let client = ethereum::DefaultEthClient::default();
                 let (logs, filter_id) = client.get_eth_logs().unwrap();
-                let signer = Signer::<T, T::AuthorityId>::all_accounts();
+                let signer = Signer::<T, T::AuthorityId>::any_account();
                 if !signer.can_sign() {
                     log::error!(
                         "No local accounts available. Consider adding one via `author_insertKey` RPC"

--- a/pallets/bridge/src/lib.rs
+++ b/pallets/bridge/src/lib.rs
@@ -338,6 +338,7 @@ pub mod pallet {
         HttpFetchingError,
         GetLockError,
         DeserializeError,
+        InvalidSubAddress,
     }
 
     #[pallet::hooks]
@@ -407,7 +408,11 @@ pub mod pallet {
                 if log.message_id.is_empty() {
                     continue;
                 }
-                // let recipient = ensure_signed(log.recipient)?;
+                let recipient_result = T::AccountId::decode(&mut &log.recipient[..]);
+                if recipient_result.is_err() {
+                    continue;
+                }
+                let recipient = recipient_result.unwrap();
 
                 let message_id = log
                     .message_id
@@ -419,7 +424,7 @@ pub mod pallet {
                     let amount = log.amount as u32;
                     let amount = BalanceOf::<T>::from(amount);
                     let sender = H160::from_slice(&log.sender);
-                    // T::Currency::deposit_creating(&recipient, amount); // mint
+                    T::Currency::deposit_creating(&recipient, amount); // mint
 
                     Self::deposit_event(Event::ApprovedEthDprTransaction(
                         message_id,

--- a/pallets/bridge/src/lib.rs
+++ b/pallets/bridge/src/lib.rs
@@ -20,6 +20,10 @@ use sp_std::prelude::*;
 pub mod weights;
 use ethereum::Client;
 use weights::WeightInfo;
+use substrate_prometheus_endpoint::{
+	prometheus::core::{Atomic, Collector},
+	register, Counter, CounterVec, Gauge, GaugeVec, Opts, PrometheusError, Registry, F64, U64,
+};
 
 pub mod crypto {
     use sp_core::crypto::KeyTypeId;

--- a/pallets/bridge/src/mock.rs
+++ b/pallets/bridge/src/mock.rs
@@ -4,13 +4,8 @@ use frame_support::{
     traits::{GenesisBuild, OnFinalize, OnInitialize},
 };
 use frame_system as system;
-use frame_system::offchain::{AppCrypto, CreateSignedTransaction, SendSignedTransaction, Signer};
 use sp_core::H256;
 use sp_core::{
-    offchain::{
-        testing::{self, OffchainState, PoolState},
-        OffchainExt, TransactionPoolExt,
-    },
     sr25519::{self, Signature},
     Pair, Public,
 };
@@ -18,7 +13,6 @@ use sp_runtime::{
     testing::{Header, TestXt},
     traits::{BlakeTwo256, Extrinsic as ExtrinsicT, IdentifyAccount, IdentityLookup, Verify},
 };
-use sp_runtime::{MultiSignature, MultiSigner};
 
 use node_primitives::{Balance, BlockNumber, Moment};
 

--- a/pallets/bridge/src/mock.rs
+++ b/pallets/bridge/src/mock.rs
@@ -4,25 +4,21 @@ use frame_support::{
     traits::{GenesisBuild, OnFinalize, OnInitialize},
 };
 use frame_system as system;
+use frame_system::offchain::{AppCrypto, CreateSignedTransaction, SendSignedTransaction, Signer};
 use sp_core::H256;
-use sp_runtime::{
-    testing::{Header, TestXt},
-    traits::{BlakeTwo256, IdentityLookup, Extrinsic as ExtrinsicT, IdentifyAccount, Verify},
-};
-use frame_system::offchain::{
-    AppCrypto, CreateSignedTransaction, SendSignedTransaction, Signer,
-};
 use sp_core::{
-	offchain::{
-		testing::{self, OffchainState, PoolState},
-		OffchainExt, TransactionPoolExt,
-	},
-	sr25519::{self, Signature},
+    offchain::{
+        testing::{self, OffchainState, PoolState},
+        OffchainExt, TransactionPoolExt,
+    },
+    sr25519::{self, Signature},
     Pair, Public,
 };
 use sp_runtime::{
-    MultiSignature, MultiSigner,
+    testing::{Header, TestXt},
+    traits::{BlakeTwo256, Extrinsic as ExtrinsicT, IdentifyAccount, IdentityLookup, Verify},
 };
+use sp_runtime::{MultiSignature, MultiSigner};
 
 use node_primitives::{Balance, BlockNumber, Moment};
 
@@ -116,31 +112,30 @@ impl pallet_eth_sub_bridge::Config for Test {
 }
 
 impl frame_system::offchain::SigningTypes for Test {
-	type Public = <Signature as Verify>::Signer;
-	type Signature = Signature;
+    type Public = <Signature as Verify>::Signer;
+    type Signature = Signature;
 }
-
 
 impl<C> frame_system::offchain::SendTransactionTypes<C> for Test
 where
-	Call: From<C>,
+    Call: From<C>,
 {
-	type OverarchingCall = Call;
-	type Extrinsic = Extrinsic;
+    type OverarchingCall = Call;
+    type Extrinsic = Extrinsic;
 }
 
 impl<LocalCall> frame_system::offchain::CreateSignedTransaction<LocalCall> for Test
 where
-	Call: From<LocalCall>,
+    Call: From<LocalCall>,
 {
-	fn create_transaction<C: frame_system::offchain::AppCrypto<Self::Public, Self::Signature>>(
-		call: Call,
-		_public: <Signature as Verify>::Signer,
-		_account: AccountId,
-		nonce: u64,
-	) -> Option<(Call, <Extrinsic as ExtrinsicT>::SignaturePayload)> {
-		Some((call, (nonce, ())))
-	}
+    fn create_transaction<C: frame_system::offchain::AppCrypto<Self::Public, Self::Signature>>(
+        call: Call,
+        _public: <Signature as Verify>::Signer,
+        _account: AccountId,
+        nonce: u64,
+    ) -> Option<(Call, <Extrinsic as ExtrinsicT>::SignaturePayload)> {
+        Some((call, (nonce, ())))
+    }
 }
 
 /// Helper function to generate a crypto pair from seed
@@ -158,59 +153,44 @@ where
     AccountPublic::from(get_from_seed::<TPublic>(seed)).into_account()
 }
 
-// pub const V1: AccountId = get_account_id_from_seed::<sr25519::Public>("V1");
-// pub const V2: AccountId = get_account_id_from_seed::<sr25519::Public>("V2");
-// pub const V3: AccountId = get_account_id_from_seed::<sr25519::Public>("V3");
-// pub const V4: AccountId = get_account_id_from_seed::<sr25519::Public>("V4");
-
-// pub const USER1: AccountId = get_account_id_from_seed::<sr25519::Public>("U1");
-// pub const USER2: AccountId = get_account_id_from_seed::<sr25519::Public>("U2");
-// pub const USER3: AccountId = get_account_id_from_seed::<sr25519::Public>("U3");
-// pub const USER4: AccountId = get_account_id_from_seed::<sr25519::Public>("U4");
-// pub const USER5: AccountId = get_account_id_from_seed::<sr25519::Public>("U5");
-// pub const USER6: AccountId = get_account_id_from_seed::<sr25519::Public>("U6");
-// pub const USER7: AccountId = get_account_id_from_seed::<sr25519::Public>("U7");
-// pub const USER8: AccountId = get_account_id_from_seed::<sr25519::Public>("U8");
-// pub const USER9: AccountId = get_account_id_from_seed::<sr25519::Public>("U9");
-
-pub fn V1() -> AccountId {
+pub fn v1() -> AccountId {
     get_account_id_from_seed::<sr25519::Public>("V1")
 }
-pub fn V2() -> AccountId {
+pub fn v2() -> AccountId {
     get_account_id_from_seed::<sr25519::Public>("V2")
 }
-pub fn V3() -> AccountId {
+pub fn v3() -> AccountId {
     get_account_id_from_seed::<sr25519::Public>("V3")
 }
-pub fn V4() -> AccountId {
+pub fn v4() -> AccountId {
     get_account_id_from_seed::<sr25519::Public>("V4")
 }
 
-pub fn USER1() -> AccountId {
+pub fn user1() -> AccountId {
     get_account_id_from_seed::<sr25519::Public>("USER1")
 }
-pub fn USER2() -> AccountId {
+pub fn user2() -> AccountId {
     get_account_id_from_seed::<sr25519::Public>("USER2")
 }
-pub fn USER3() -> AccountId {
+pub fn user3() -> AccountId {
     get_account_id_from_seed::<sr25519::Public>("USER3")
 }
-pub fn USER4() -> AccountId {
+pub fn user4() -> AccountId {
     get_account_id_from_seed::<sr25519::Public>("USER4")
 }
-pub fn USER5() -> AccountId {
+pub fn user5() -> AccountId {
     get_account_id_from_seed::<sr25519::Public>("USER5")
 }
-pub fn USER6() -> AccountId {
+pub fn user6() -> AccountId {
     get_account_id_from_seed::<sr25519::Public>("USER6")
 }
-pub fn USER7() -> AccountId {
+pub fn user7() -> AccountId {
     get_account_id_from_seed::<sr25519::Public>("USER7")
 }
-pub fn USER8() -> AccountId {
+pub fn user8() -> AccountId {
     get_account_id_from_seed::<sr25519::Public>("USER8")
 }
-pub fn USER9() -> AccountId {
+pub fn user9() -> AccountId {
     get_account_id_from_seed::<sr25519::Public>("USER9")
 }
 
@@ -222,18 +202,18 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 
     let _ = pallet_balances::GenesisConfig::<Test> {
         balances: vec![
-            (V1(), 100000),
-            (V2(), 100000),
-            (V3(), 100000),
-            (USER1(), 100000),
-            (USER2(), 300000),
+            (v1(), 100000),
+            (v2(), 100000),
+            (v3(), 100000),
+            (user1(), 100000),
+            (user2(), 300000),
         ],
     }
     .assimilate_storage(&mut storage);
 
     let _ = pallet_eth_sub_bridge::GenesisConfig::<Test> {
         validators_count: 3u32,
-        validator_accounts: vec![V1(), V2(), V3()],
+        validator_accounts: vec![v1(), v2(), v3()],
         current_limits: vec![100, 200, 50, 400, 10],
     }
     .assimilate_storage(&mut storage);

--- a/pallets/bridge/src/mock.rs
+++ b/pallets/bridge/src/mock.rs
@@ -1,4 +1,4 @@
-use crate::{self as pallet_eth_sub_bridge, crypto::TestAuthId};
+use crate::{self as pallet_eth_sub_bridge, crypto::TestAuthId, ethereum};
 use frame_support::{
     parameter_types,
     traits::{GenesisBuild, OnFinalize, OnInitialize},
@@ -109,6 +109,7 @@ impl pallet_eth_sub_bridge::Config for Test {
     type WeightInfo = ();
     type AuthorityId = TestAuthId;
     type Call = Call;
+    type EthClient = ethereum::MockEthClient;
 }
 
 impl frame_system::offchain::SigningTypes for Test {

--- a/pallets/bridge/src/tests.rs
+++ b/pallets/bridge/src/tests.rs
@@ -1,6 +1,7 @@
 use crate::{mock::*, types::Status};
 use frame_support::{assert_noop, assert_ok, dispatch::DispatchErrorWithPostInfo};
-use sp_core::{H160, H256};
+use sp_core::{H160, H256, sr25519};
+// use crate::mock::USER2();
 
 const DAY_IN_BLOCKS: u32 = 14_400;
 
@@ -15,20 +16,20 @@ const ETH_MESSAGE_ID7: &[u8; 32] = b"0x5617jqu391571b5dc8230db92ba65b";
 const ETH_MESSAGE_ID8: &[u8; 32] = b"0x5617pbt391571b5dc8230db92ba65b";
 const ETH_ADDRESS: &[u8; 20] = b"0x00b46c2526ebb8f4c9";
 
-const V1: u64 = 1;
-const V2: u64 = 2;
-const V3: u64 = 3;
-const V4: u64 = 4;
+// const V1(): u64 = 1;
+// const V2(): u64 = 2;
+// const V3(): u64 = 3;
+// const V4(): u64 = 4;
 
-const USER1: u64 = 5;
-const USER2: u64 = 6;
-const USER3: u64 = 7;
-const USER4: u64 = 8;
-const USER5: u64 = 9;
-const USER6: u64 = 10;
-const USER7: u64 = 11;
-const USER8: u64 = 12;
-const USER9: u64 = 13;
+// const USER1(): u64 = 5;
+// const USER2(): u64 = 6;
+// const USER3(): u64 = 7;
+// const USER4(): u64 = 8;
+// const USER5(): u64 = 9;
+// const USER6(): u64 = 10;
+// const USER7(): u64 = 11;
+// const USER8(): u64 = 12;
+// const USER9(): u64 = 13;
 
 #[test]
 fn eth2sub_mint_works() {
@@ -36,25 +37,25 @@ fn eth2sub_mint_works() {
         let message_id = H256::from(ETH_MESSAGE_ID);
         let eth_address = H160::from(ETH_ADDRESS);
         let amount = 99;
-        let balance_of_user2 = Balances::free_balance(USER2);
+        let balance_of_user2 = Balances::free_balance(USER2());
         let total_issuance = Balances::total_issuance();
 
         //substrate <----- ETH
         assert_ok!(Bridge::multi_signed_mint(
-            Origin::signed(V2),
+            Origin::signed(V2()),
             message_id,
             eth_address,
-            USER2,
+            USER2(),
             amount
         ));
         let mut message = Bridge::messages(message_id);
         assert_eq!(message.status, Status::Pending);
 
         assert_ok!(Bridge::multi_signed_mint(
-            Origin::signed(V1),
+            Origin::signed(V1()),
             message_id,
             eth_address,
-            USER2,
+            USER2(),
             amount
         ));
         message = Bridge::messages(message_id);
@@ -63,7 +64,7 @@ fn eth2sub_mint_works() {
         let transfer = Bridge::transfers(0);
         assert_eq!(transfer.open, false);
 
-        assert_eq!(Balances::free_balance(USER2), amount + balance_of_user2);
+        assert_eq!(Balances::free_balance(USER2()), amount + balance_of_user2);
         assert_eq!(Balances::total_issuance(), amount + total_issuance);
     });
 }
@@ -77,14 +78,14 @@ fn eth2sub_mint_should_fail() {
         let amount2 = 101;
 
         assert_eq!(
-            Bridge::multi_signed_mint(Origin::signed(V2), message_id, eth_address, USER2, amount1),
+            Bridge::multi_signed_mint(Origin::signed(V2()), message_id, eth_address, USER2(), amount1),
             Err(DispatchErrorWithPostInfo::from(
                 "Invalid amount for transaction. Reached minimum limit."
             ))
         );
 
         assert_eq!(
-            Bridge::multi_signed_mint(Origin::signed(V1), message_id, eth_address, USER2, amount2),
+            Bridge::multi_signed_mint(Origin::signed(V1()), message_id, eth_address, USER2(), amount2),
             Err(DispatchErrorWithPostInfo::from(
                 "Invalid amount for transaction. Reached maximum limit."
             ))
@@ -97,12 +98,12 @@ fn sub2eth_burn_works() {
     new_test_ext().execute_with(|| {
         let eth_address = H160::from(ETH_ADDRESS);
         let amount2 = 49;
-        let balance_of_user2 = Balances::free_balance(USER2);
+        let balance_of_user2 = Balances::free_balance(USER2());
         let total_issuance = Balances::total_issuance();
 
         //substrate ----> ETH
         assert_ok!(Bridge::set_transfer(
-            Origin::signed(USER2),
+            Origin::signed(USER2()),
             eth_address,
             amount2
         ));
@@ -115,9 +116,9 @@ fn sub2eth_burn_works() {
         assert_eq!(message.status, Status::Withdraw);
 
         //approval
-        assert_eq!(Balances::free_balance(USER2), balance_of_user2);
-        assert_ok!(Bridge::approve_transfer(Origin::signed(V1), sub_message_id));
-        assert_ok!(Bridge::approve_transfer(Origin::signed(V2), sub_message_id));
+        assert_eq!(Balances::free_balance(USER2()), balance_of_user2);
+        assert_ok!(Bridge::approve_transfer(Origin::signed(V1()), sub_message_id));
+        assert_ok!(Bridge::approve_transfer(Origin::signed(V2()), sub_message_id));
 
         message = get_message();
         assert_eq!(message.status, Status::Approved);
@@ -125,18 +126,18 @@ fn sub2eth_burn_works() {
         // at this point transfer is in Approved status and are waiting for confirmation
         // from ethereum side to burn. Funds are locked.
 
-        assert_eq!(Balances::reserved_balance(USER2), amount2);
+        assert_eq!(Balances::reserved_balance(USER2()), amount2);
 
-        assert_ok!(Bridge::confirm_transfer(Origin::signed(V2), sub_message_id));
+        assert_ok!(Bridge::confirm_transfer(Origin::signed(V2()), sub_message_id));
 
         message = get_message();
         let transfer = Bridge::transfers(1);
         assert_eq!(message.status, Status::Confirmed);
         assert_eq!(transfer.open, true);
-        assert_ok!(Bridge::confirm_transfer(Origin::signed(V1), sub_message_id));
-        // assert_ok!(Bridge::confirm_transfer(Origin::signed(USER1), sub_message_id));
+        assert_ok!(Bridge::confirm_transfer(Origin::signed(V1()), sub_message_id));
+        // assert_ok!(Bridge::confirm_transfer(Origin::signed(USER1()), sub_message_id));
         //BurnedMessage(Hash, AccountId, H160, u64) event emitted
-        assert_eq!(Balances::free_balance(USER2), balance_of_user2 - amount2);
+        assert_eq!(Balances::free_balance(USER2()), balance_of_user2 - amount2);
         assert_eq!(Balances::total_issuance(), total_issuance - amount2);
     })
 }
@@ -149,7 +150,7 @@ fn sub2eth_burn_skipped_approval_should_fail() {
 
         //substrate ----> ETH
         assert_ok!(Bridge::set_transfer(
-            Origin::signed(USER2),
+            Origin::signed(USER2()),
             eth_address,
             amount2
         ));
@@ -159,11 +160,11 @@ fn sub2eth_burn_skipped_approval_should_fail() {
         let message = Bridge::messages(sub_message_id);
         assert_eq!(message.status, Status::Withdraw);
 
-        assert_eq!(Balances::reserved_balance(USER2), 0);
+        assert_eq!(Balances::reserved_balance(USER2()), 0);
         // lets say validators blacked out and we
         // try to confirm without approval anyway
         assert_noop!(
-            Bridge::confirm_transfer(Origin::signed(V1), sub_message_id),
+            Bridge::confirm_transfer(Origin::signed(V1()), sub_message_id),
             "This transfer must be approved first."
         );
     })
@@ -177,19 +178,19 @@ fn sub2eth_burn_cancel_works() {
 
         //substrate ----> ETH
         assert_ok!(Bridge::set_transfer(
-            Origin::signed(USER2),
+            Origin::signed(USER2()),
             eth_address,
             amount2
         ));
 
         let sub_message_id = Bridge::message_id_by_transfer_id(0);
-        assert_ok!(Bridge::approve_transfer(Origin::signed(V1), sub_message_id));
-        assert_ok!(Bridge::approve_transfer(Origin::signed(V2), sub_message_id));
+        assert_ok!(Bridge::approve_transfer(Origin::signed(V1()), sub_message_id));
+        assert_ok!(Bridge::approve_transfer(Origin::signed(V2()), sub_message_id));
         let mut message = Bridge::messages(sub_message_id);
         // funds are locked and waiting for confirmation
         assert_eq!(message.status, Status::Approved);
-        assert_ok!(Bridge::cancel_transfer(Origin::signed(V2), sub_message_id));
-        assert_ok!(Bridge::cancel_transfer(Origin::signed(V3), sub_message_id));
+        assert_ok!(Bridge::cancel_transfer(Origin::signed(V2()), sub_message_id));
+        assert_ok!(Bridge::cancel_transfer(Origin::signed(V3()), sub_message_id));
         message = Bridge::messages(sub_message_id);
         assert_eq!(message.status, Status::Canceled);
     })
@@ -201,12 +202,12 @@ fn burn_cancel_should_fail() {
         let eth_address = H160::from(ETH_ADDRESS);
         let amount2 = 49;
 
-        let balance_of_user2 = Balances::free_balance(USER2);
+        let balance_of_user2 = Balances::free_balance(USER2());
         let total_issuance = Balances::total_issuance();
 
         //substrate ----> ETH
         assert_ok!(Bridge::set_transfer(
-            Origin::signed(USER2),
+            Origin::signed(USER2()),
             eth_address,
             amount2
         ));
@@ -218,33 +219,33 @@ fn burn_cancel_should_fail() {
         assert_eq!(message.status, Status::Withdraw);
 
         //approval
-        assert_eq!(Balances::reserved_balance(USER2), 0);
-        assert_ok!(Bridge::approve_transfer(Origin::signed(V1), sub_message_id));
-        assert_ok!(Bridge::approve_transfer(Origin::signed(V2), sub_message_id));
+        assert_eq!(Balances::reserved_balance(USER2()), 0);
+        assert_ok!(Bridge::approve_transfer(Origin::signed(V1()), sub_message_id));
+        assert_ok!(Bridge::approve_transfer(Origin::signed(V2()), sub_message_id));
 
         message = get_message();
         assert_eq!(message.status, Status::Approved);
 
         // at this point transfer is in Approved status and are waiting for confirmation
         // from ethereum side to burn. Funds are locked.
-        assert_eq!(Balances::reserved_balance(USER2), amount2);
-        assert_eq!(Balances::free_balance(USER2), balance_of_user2 - amount2);
+        assert_eq!(Balances::reserved_balance(USER2()), amount2);
+        assert_eq!(Balances::free_balance(USER2()), balance_of_user2 - amount2);
         // once it happends, validators call confirm_transfer
 
-        assert_ok!(Bridge::confirm_transfer(Origin::signed(V2), sub_message_id));
+        assert_ok!(Bridge::confirm_transfer(Origin::signed(V2()), sub_message_id));
 
         message = get_message();
         let transfer = Bridge::transfers(1);
         assert_eq!(message.status, Status::Confirmed);
         assert_eq!(transfer.open, true);
-        assert_ok!(Bridge::confirm_transfer(Origin::signed(V1), sub_message_id));
-        // assert_ok!(Bridge::confirm_transfer(Origin::signed(USER1), sub_message_id));
+        assert_ok!(Bridge::confirm_transfer(Origin::signed(V1()), sub_message_id));
+        // assert_ok!(Bridge::confirm_transfer(Origin::signed(USER1()), sub_message_id));
         //BurnedMessage(Hash, AccountId, H160, u64) event emitted
 
-        assert_eq!(Balances::free_balance(USER2), balance_of_user2 - amount2);
+        assert_eq!(Balances::free_balance(USER2()), balance_of_user2 - amount2);
         assert_eq!(Balances::total_issuance(), total_issuance - amount2);
         assert_noop!(
-            Bridge::cancel_transfer(Origin::signed(V2), sub_message_id),
+            Bridge::cancel_transfer(Origin::signed(V2()), sub_message_id),
             "Failed to cancel. This transfer is already executed."
         );
     })
@@ -257,20 +258,20 @@ fn update_validator_list_should_work() {
         const QUORUM: u64 = 3;
 
         assert_ok!(Bridge::update_validator_list(
-            Origin::signed(V2),
+            Origin::signed(V2()),
             eth_message_id,
             QUORUM,
-            vec![V1, V2, V3, V4]
+            vec![V1(), V2(), V3(), V4()]
         ));
         let id = Bridge::message_id_by_transfer_id(0);
         let mut message = Bridge::validator_history(id);
         assert_eq!(message.status, Status::Pending);
 
         assert_ok!(Bridge::update_validator_list(
-            Origin::signed(V1),
+            Origin::signed(V1()),
             eth_message_id,
             QUORUM,
-            vec![V1, V2, V3, V4]
+            vec![V1(), V2(), V3(), V4()]
         ));
         message = Bridge::validator_history(id);
         assert_eq!(message.status, Status::Confirmed);
@@ -281,7 +282,7 @@ fn update_validator_list_should_work() {
 #[test]
 fn pause_the_bridge_should_work() {
     new_test_ext().execute_with(|| {
-        assert_ok!(Bridge::pause_bridge(Origin::signed(V2)));
+        assert_ok!(Bridge::pause_bridge(Origin::signed(V2())));
 
         assert_eq!(Bridge::bridge_transfers_count(), 1);
         assert_eq!(Bridge::bridge_is_operational(), true);
@@ -289,7 +290,7 @@ fn pause_the_bridge_should_work() {
         let mut message = Bridge::bridge_messages(id);
         assert_eq!(message.status, Status::Pending);
 
-        assert_ok!(Bridge::pause_bridge(Origin::signed(V1)));
+        assert_ok!(Bridge::pause_bridge(Origin::signed(V1())));
         assert_eq!(Bridge::bridge_is_operational(), false);
         message = Bridge::bridge_messages(id);
         assert_eq!(message.status, Status::Confirmed);
@@ -302,12 +303,12 @@ fn extrinsics_restricted_should_fail() {
         let eth_message_id = H256::from(ETH_MESSAGE_ID);
         let eth_address = H160::from(ETH_ADDRESS);
 
-        assert_ok!(Bridge::pause_bridge(Origin::signed(V2)));
-        assert_ok!(Bridge::pause_bridge(Origin::signed(V1)));
+        assert_ok!(Bridge::pause_bridge(Origin::signed(V2())));
+        assert_ok!(Bridge::pause_bridge(Origin::signed(V1())));
 
         // substrate <-- Ethereum
         assert_noop!(
-            Bridge::multi_signed_mint(Origin::signed(V2), eth_message_id, eth_address, USER2, 1000),
+            Bridge::multi_signed_mint(Origin::signed(V2()), eth_message_id, eth_address, USER2(), 1000),
             "Bridge is not operational"
         );
     })
@@ -317,11 +318,11 @@ fn extrinsics_restricted_should_fail() {
 fn double_pause_should_fail() {
     new_test_ext().execute_with(|| {
         assert_eq!(Bridge::bridge_is_operational(), true);
-        assert_ok!(Bridge::pause_bridge(Origin::signed(V2)));
-        assert_ok!(Bridge::pause_bridge(Origin::signed(V1)));
+        assert_ok!(Bridge::pause_bridge(Origin::signed(V2())));
+        assert_ok!(Bridge::pause_bridge(Origin::signed(V1())));
         assert_eq!(Bridge::bridge_is_operational(), false);
         assert_noop!(
-            Bridge::pause_bridge(Origin::signed(V1)),
+            Bridge::pause_bridge(Origin::signed(V1())),
             "Bridge is not operational already"
         );
     })
@@ -330,11 +331,11 @@ fn double_pause_should_fail() {
 fn pause_and_resume_the_bridge_should_work() {
     new_test_ext().execute_with(|| {
         assert_eq!(Bridge::bridge_is_operational(), true);
-        assert_ok!(Bridge::pause_bridge(Origin::signed(V2)));
-        assert_ok!(Bridge::pause_bridge(Origin::signed(V1)));
+        assert_ok!(Bridge::pause_bridge(Origin::signed(V2())));
+        assert_ok!(Bridge::pause_bridge(Origin::signed(V1())));
         assert_eq!(Bridge::bridge_is_operational(), false);
-        assert_ok!(Bridge::resume_bridge(Origin::signed(V1)));
-        assert_ok!(Bridge::resume_bridge(Origin::signed(V2)));
+        assert_ok!(Bridge::resume_bridge(Origin::signed(V1())));
+        assert_ok!(Bridge::resume_bridge(Origin::signed(V2())));
         assert_eq!(Bridge::bridge_is_operational(), true);
     })
 }
@@ -343,9 +344,9 @@ fn pause_and_resume_the_bridge_should_work() {
 fn double_vote_should_fail() {
     new_test_ext().execute_with(|| {
         assert_eq!(Bridge::bridge_is_operational(), true);
-        assert_ok!(Bridge::pause_bridge(Origin::signed(V2)));
+        assert_ok!(Bridge::pause_bridge(Origin::signed(V2())));
         assert_noop!(
-            Bridge::pause_bridge(Origin::signed(V2)),
+            Bridge::pause_bridge(Origin::signed(V2())),
             "This validator has already voted."
         );
     })
@@ -361,22 +362,22 @@ fn instant_withdraw_should_fail() {
 
         //substrate <----- ETH
         assert_ok!(Bridge::multi_signed_mint(
-            Origin::signed(V2),
+            Origin::signed(V2()),
             eth_message_id,
             eth_address,
-            USER3,
+            USER3(),
             amount1
         ));
         assert_ok!(Bridge::multi_signed_mint(
-            Origin::signed(V1),
+            Origin::signed(V1()),
             eth_message_id,
             eth_address,
-            USER3,
+            USER3(),
             amount1
         ));
         //substrate ----> ETH
         assert_ok!(Bridge::set_transfer(
-            Origin::signed(USER3),
+            Origin::signed(USER3()),
             eth_address,
             amount2
         ));
@@ -386,11 +387,11 @@ fn instant_withdraw_should_fail() {
         let mut message = get_message();
         assert_eq!(message.status, Status::Withdraw);
         //approval
-        assert_eq!(Balances::reserved_balance(USER3), 0);
-        assert_ok!(Bridge::approve_transfer(Origin::signed(V1), sub_message_id));
+        assert_eq!(Balances::reserved_balance(USER3()), 0);
+        assert_ok!(Bridge::approve_transfer(Origin::signed(V1()), sub_message_id));
 
         assert_eq!(
-            Bridge::approve_transfer(Origin::signed(V2), sub_message_id),
+            Bridge::approve_transfer(Origin::signed(V2()), sub_message_id),
             Err(DispatchErrorWithPostInfo::from(
                 "Cannot withdraw more that 75% of first day deposit."
             ))
@@ -412,7 +413,7 @@ fn change_limits_should_work() {
 
         assert_eq!(Bridge::current_limits().max_tx_value, 100);
         assert_ok!(Bridge::update_limits(
-            Origin::signed(V2),
+            Origin::signed(V2()),
             max_tx_value,
             day_max_limit,
             day_max_limit_for_one_address,
@@ -420,7 +421,7 @@ fn change_limits_should_work() {
             min_tx_value,
         ));
         assert_ok!(Bridge::update_limits(
-            Origin::signed(V1),
+            Origin::signed(V1()),
             max_tx_value,
             day_max_limit,
             day_max_limit_for_one_address,
@@ -442,7 +443,7 @@ fn change_limits_should_fail() {
 
         assert_noop!(
             Bridge::update_limits(
-                Origin::signed(V1),
+                Origin::signed(V1()),
                 MORE_THAN_MAX,
                 day_max_limit,
                 day_max_limit_for_one_address,
@@ -461,82 +462,82 @@ fn pending_burn_limit_should_work() {
         let amount1 = 60;
         let amount2 = 49;
         //TODO: pending transactions volume never reached if daily limit is lower
-        // USER1, USER2 init in mock.rs
-        let _ = Balances::transfer(Origin::signed(USER1), USER3, amount1);
-        let _ = Balances::transfer(Origin::signed(USER1), USER4, amount1);
-        let _ = Balances::transfer(Origin::signed(USER1), USER5, amount1);
-        let _ = Balances::transfer(Origin::signed(USER1), USER6, amount1);
-        let _ = Balances::transfer(Origin::signed(USER1), USER7, amount1);
-        let _ = Balances::transfer(Origin::signed(USER1), USER8, amount1);
-        let _ = Balances::transfer(Origin::signed(USER1), USER9, amount1);
+        // USER1(), USER2() init in mock.rs
+        let _ = Balances::transfer(Origin::signed(USER1()), USER3(), amount1);
+        let _ = Balances::transfer(Origin::signed(USER1()), USER4(), amount1);
+        let _ = Balances::transfer(Origin::signed(USER1()), USER5(), amount1);
+        let _ = Balances::transfer(Origin::signed(USER1()), USER6(), amount1);
+        let _ = Balances::transfer(Origin::signed(USER1()), USER7(), amount1);
+        let _ = Balances::transfer(Origin::signed(USER1()), USER8(), amount1);
+        let _ = Balances::transfer(Origin::signed(USER1()), USER9(), amount1);
         //1
         assert_ok!(Bridge::set_transfer(
-            Origin::signed(USER2),
+            Origin::signed(USER2()),
             eth_address,
             amount2
         ));
         let sub_message_id = Bridge::message_id_by_transfer_id(0);
-        assert_ok!(Bridge::approve_transfer(Origin::signed(V1), sub_message_id));
+        assert_ok!(Bridge::approve_transfer(Origin::signed(V1()), sub_message_id));
 
         assert_ok!(Bridge::set_transfer(
-            Origin::signed(USER3),
+            Origin::signed(USER3()),
             eth_address,
             amount2
         ));
         let sub_message_id = Bridge::message_id_by_transfer_id(1);
-        assert_ok!(Bridge::approve_transfer(Origin::signed(V1), sub_message_id));
+        assert_ok!(Bridge::approve_transfer(Origin::signed(V1()), sub_message_id));
 
         assert_ok!(Bridge::set_transfer(
-            Origin::signed(USER4),
+            Origin::signed(USER4()),
             eth_address,
             amount2
         ));
         let sub_message_id = Bridge::message_id_by_transfer_id(2);
-        assert_ok!(Bridge::approve_transfer(Origin::signed(V1), sub_message_id));
+        assert_ok!(Bridge::approve_transfer(Origin::signed(V1()), sub_message_id));
 
         assert_ok!(Bridge::set_transfer(
-            Origin::signed(USER5),
+            Origin::signed(USER5()),
             eth_address,
             amount2
         ));
         let sub_message_id = Bridge::message_id_by_transfer_id(3);
-        assert_ok!(Bridge::approve_transfer(Origin::signed(V1), sub_message_id));
+        assert_ok!(Bridge::approve_transfer(Origin::signed(V1()), sub_message_id));
 
         assert_ok!(Bridge::set_transfer(
-            Origin::signed(USER6),
+            Origin::signed(USER6()),
             eth_address,
             amount2
         ));
         let sub_message_id = Bridge::message_id_by_transfer_id(4);
-        assert_ok!(Bridge::approve_transfer(Origin::signed(V1), sub_message_id));
+        assert_ok!(Bridge::approve_transfer(Origin::signed(V1()), sub_message_id));
 
         assert_ok!(Bridge::set_transfer(
-            Origin::signed(USER7),
+            Origin::signed(USER7()),
             eth_address,
             amount2
         ));
         let sub_message_id = Bridge::message_id_by_transfer_id(5);
-        assert_ok!(Bridge::approve_transfer(Origin::signed(V1), sub_message_id));
+        assert_ok!(Bridge::approve_transfer(Origin::signed(V1()), sub_message_id));
 
         assert_ok!(Bridge::set_transfer(
-            Origin::signed(USER8),
+            Origin::signed(USER8()),
             eth_address,
             amount2
         ));
         let sub_message_id = Bridge::message_id_by_transfer_id(6);
-        assert_ok!(Bridge::approve_transfer(Origin::signed(V1), sub_message_id));
+        assert_ok!(Bridge::approve_transfer(Origin::signed(V1()), sub_message_id));
 
         assert_ok!(Bridge::set_transfer(
-            Origin::signed(USER9),
+            Origin::signed(USER9()),
             eth_address,
             amount2
         ));
         let sub_message_id = Bridge::message_id_by_transfer_id(7);
-        assert_ok!(Bridge::approve_transfer(Origin::signed(V1), sub_message_id));
+        assert_ok!(Bridge::approve_transfer(Origin::signed(V1()), sub_message_id));
 
         assert_eq!(Bridge::pending_burn_count(), amount2 * 8);
         assert_noop!(
-            Bridge::set_transfer(Origin::signed(USER1), eth_address, amount2),
+            Bridge::set_transfer(Origin::signed(USER1()), eth_address, amount2),
             "Too many pending burn transactions."
         );
     })
@@ -559,69 +560,69 @@ fn pending_mint_limit_should_work() {
 
         //substrate <----- ETH
         assert_ok!(Bridge::multi_signed_mint(
-            Origin::signed(V2),
+            Origin::signed(V2()),
             eth_message_id,
             eth_address,
-            USER2,
+            USER2(),
             amount1
         ));
 
         //substrate <----- ETH
         assert_ok!(Bridge::multi_signed_mint(
-            Origin::signed(V2),
+            Origin::signed(V2()),
             eth_message_id2,
             eth_address,
-            USER3,
+            USER3(),
             amount1
         ));
 
         //substrate <----- ETH
         assert_ok!(Bridge::multi_signed_mint(
-            Origin::signed(V2),
+            Origin::signed(V2()),
             eth_message_id3,
             eth_address,
-            USER4,
+            USER4(),
             amount1
         ));
 
         //substrate <----- ETH
         assert_ok!(Bridge::multi_signed_mint(
-            Origin::signed(V2),
+            Origin::signed(V2()),
             eth_message_id4,
             eth_address,
-            USER5,
+            USER5(),
             amount1
         ));
         //substrate <----- ETH
         assert_ok!(Bridge::multi_signed_mint(
-            Origin::signed(V2),
+            Origin::signed(V2()),
             eth_message_id5,
             eth_address,
-            USER6,
+            USER6(),
             amount1
         ));
         //substrate <----- ETH
         assert_ok!(Bridge::multi_signed_mint(
-            Origin::signed(V2),
+            Origin::signed(V2()),
             eth_message_id6,
             eth_address,
-            USER7,
+            USER7(),
             amount1
         ));
         //substrate <----- ETH
         assert_ok!(Bridge::multi_signed_mint(
-            Origin::signed(V2),
+            Origin::signed(V2()),
             eth_message_id7,
             eth_address,
-            USER8,
+            USER8(),
             amount1
         ));
         //substrate <----- ETH
         assert_ok!(Bridge::multi_signed_mint(
-            Origin::signed(V2),
+            Origin::signed(V2()),
             eth_message_id8,
             eth_address,
-            USER9,
+            USER9(),
             amount1
         ));
         assert_eq!(Bridge::pending_mint_count(), amount1 * 8);
@@ -629,10 +630,10 @@ fn pending_mint_limit_should_work() {
         //substrate <----- ETH
         assert_noop!(
             Bridge::multi_signed_mint(
-                Origin::signed(V2),
+                Origin::signed(V2()),
                 eth_message_id1,
                 eth_address,
-                USER1,
+                USER1(),
                 amount1 + 5
             ),
             "Too many pending mint transactions."
@@ -649,30 +650,30 @@ fn blocking_account_by_volume_should_work() {
         let amount3 = 101;
 
         assert_eq!(
-            Bridge::set_transfer(Origin::signed(USER2), eth_address, amount1),
+            Bridge::set_transfer(Origin::signed(USER2()), eth_address, amount1),
             Err(DispatchErrorWithPostInfo::from(
                 "Invalid amount for transaction. Reached minimum limit."
             ))
         );
 
         assert_eq!(
-            Bridge::set_transfer(Origin::signed(USER2), eth_address, amount3),
+            Bridge::set_transfer(Origin::signed(USER2()), eth_address, amount3),
             Err(DispatchErrorWithPostInfo::from(
                 "Invalid amount for transaction. Reached maximum limit."
             ))
         );
 
         assert_ok!(Bridge::set_transfer(
-            Origin::signed(USER2),
+            Origin::signed(USER2()),
             eth_address,
             amount2
         ));
         let sub_message_id = Bridge::message_id_by_transfer_id(0);
-        assert_ok!(Bridge::approve_transfer(Origin::signed(V1), sub_message_id));
-        assert_ok!(Bridge::approve_transfer(Origin::signed(V2), sub_message_id));
+        assert_ok!(Bridge::approve_transfer(Origin::signed(V1()), sub_message_id));
+        assert_ok!(Bridge::approve_transfer(Origin::signed(V2()), sub_message_id));
 
         assert_eq!(
-            Bridge::set_transfer(Origin::signed(USER2), eth_address, amount2),
+            Bridge::set_transfer(Origin::signed(USER2()), eth_address, amount2),
             Err(DispatchErrorWithPostInfo::from(
                 "Transfer declined, user blocked due to daily volume limit."
             ))
@@ -688,22 +689,22 @@ fn blocked_account_unblocked_next_day_should_work() {
         run_to_block(DAY_IN_BLOCKS.into());
 
         assert_ok!(Bridge::set_transfer(
-            Origin::signed(USER2),
+            Origin::signed(USER2()),
             eth_address,
             amount2
         ));
         let sub_message_id = Bridge::message_id_by_transfer_id(0);
-        assert_ok!(Bridge::approve_transfer(Origin::signed(V1), sub_message_id));
-        assert_ok!(Bridge::approve_transfer(Origin::signed(V2), sub_message_id));
+        assert_ok!(Bridge::approve_transfer(Origin::signed(V1()), sub_message_id));
+        assert_ok!(Bridge::approve_transfer(Origin::signed(V2()), sub_message_id));
         assert_eq!(
-            Bridge::set_transfer(Origin::signed(USER2), eth_address, amount2),
+            Bridge::set_transfer(Origin::signed(USER2()), eth_address, amount2),
             Err(DispatchErrorWithPostInfo::from(
                 "Transfer declined, user blocked due to daily volume limit."
             ))
         );
 
         //user added to blocked vec
-        let blocked_vec: Vec<u64> = vec![USER2];
+        let blocked_vec: Vec<sr25519::Public> = vec![USER2()];
         assert_eq!(Bridge::daily_blocked(1), blocked_vec);
 
         run_to_block((DAY_IN_BLOCKS * 2).into());
@@ -711,7 +712,7 @@ fn blocked_account_unblocked_next_day_should_work() {
 
         //try again
         assert_ok!(Bridge::set_transfer(
-            Origin::signed(USER2),
+            Origin::signed(USER2()),
             eth_address,
             amount2
         ));

--- a/pallets/bridge/src/tests.rs
+++ b/pallets/bridge/src/tests.rs
@@ -1,7 +1,6 @@
 use crate::{mock::*, types::Status};
 use frame_support::{assert_noop, assert_ok, dispatch::DispatchErrorWithPostInfo};
-use sp_core::{H160, H256, sr25519};
-// use crate::mock::USER2();
+use sp_core::{sr25519, H160, H256};
 
 const DAY_IN_BLOCKS: u32 = 14_400;
 
@@ -16,46 +15,31 @@ const ETH_MESSAGE_ID7: &[u8; 32] = b"0x5617jqu391571b5dc8230db92ba65b";
 const ETH_MESSAGE_ID8: &[u8; 32] = b"0x5617pbt391571b5dc8230db92ba65b";
 const ETH_ADDRESS: &[u8; 20] = b"0x00b46c2526ebb8f4c9";
 
-// const V1(): u64 = 1;
-// const V2(): u64 = 2;
-// const V3(): u64 = 3;
-// const V4(): u64 = 4;
-
-// const USER1(): u64 = 5;
-// const USER2(): u64 = 6;
-// const USER3(): u64 = 7;
-// const USER4(): u64 = 8;
-// const USER5(): u64 = 9;
-// const USER6(): u64 = 10;
-// const USER7(): u64 = 11;
-// const USER8(): u64 = 12;
-// const USER9(): u64 = 13;
-
 #[test]
 fn eth2sub_mint_works() {
     new_test_ext().execute_with(|| {
         let message_id = H256::from(ETH_MESSAGE_ID);
         let eth_address = H160::from(ETH_ADDRESS);
         let amount = 99;
-        let balance_of_user2 = Balances::free_balance(USER2());
+        let balance_of_user2 = Balances::free_balance(user2());
         let total_issuance = Balances::total_issuance();
 
         //substrate <----- ETH
         assert_ok!(Bridge::multi_signed_mint(
-            Origin::signed(V2()),
+            Origin::signed(v2()),
             message_id,
             eth_address,
-            USER2(),
+            user2(),
             amount
         ));
         let mut message = Bridge::messages(message_id);
         assert_eq!(message.status, Status::Pending);
 
         assert_ok!(Bridge::multi_signed_mint(
-            Origin::signed(V1()),
+            Origin::signed(v1()),
             message_id,
             eth_address,
-            USER2(),
+            user2(),
             amount
         ));
         message = Bridge::messages(message_id);
@@ -64,7 +48,7 @@ fn eth2sub_mint_works() {
         let transfer = Bridge::transfers(0);
         assert_eq!(transfer.open, false);
 
-        assert_eq!(Balances::free_balance(USER2()), amount + balance_of_user2);
+        assert_eq!(Balances::free_balance(user2()), amount + balance_of_user2);
         assert_eq!(Balances::total_issuance(), amount + total_issuance);
     });
 }
@@ -78,14 +62,26 @@ fn eth2sub_mint_should_fail() {
         let amount2 = 101;
 
         assert_eq!(
-            Bridge::multi_signed_mint(Origin::signed(V2()), message_id, eth_address, USER2(), amount1),
+            Bridge::multi_signed_mint(
+                Origin::signed(v2()),
+                message_id,
+                eth_address,
+                user2(),
+                amount1
+            ),
             Err(DispatchErrorWithPostInfo::from(
                 "Invalid amount for transaction. Reached minimum limit."
             ))
         );
 
         assert_eq!(
-            Bridge::multi_signed_mint(Origin::signed(V1()), message_id, eth_address, USER2(), amount2),
+            Bridge::multi_signed_mint(
+                Origin::signed(v1()),
+                message_id,
+                eth_address,
+                user2(),
+                amount2
+            ),
             Err(DispatchErrorWithPostInfo::from(
                 "Invalid amount for transaction. Reached maximum limit."
             ))
@@ -98,12 +94,12 @@ fn sub2eth_burn_works() {
     new_test_ext().execute_with(|| {
         let eth_address = H160::from(ETH_ADDRESS);
         let amount2 = 49;
-        let balance_of_user2 = Balances::free_balance(USER2());
+        let balance_of_user2 = Balances::free_balance(user2());
         let total_issuance = Balances::total_issuance();
 
         //substrate ----> ETH
         assert_ok!(Bridge::set_transfer(
-            Origin::signed(USER2()),
+            Origin::signed(user2()),
             eth_address,
             amount2
         ));
@@ -116,9 +112,15 @@ fn sub2eth_burn_works() {
         assert_eq!(message.status, Status::Withdraw);
 
         //approval
-        assert_eq!(Balances::free_balance(USER2()), balance_of_user2);
-        assert_ok!(Bridge::approve_transfer(Origin::signed(V1()), sub_message_id));
-        assert_ok!(Bridge::approve_transfer(Origin::signed(V2()), sub_message_id));
+        assert_eq!(Balances::free_balance(user2()), balance_of_user2);
+        assert_ok!(Bridge::approve_transfer(
+            Origin::signed(v1()),
+            sub_message_id
+        ));
+        assert_ok!(Bridge::approve_transfer(
+            Origin::signed(v2()),
+            sub_message_id
+        ));
 
         message = get_message();
         assert_eq!(message.status, Status::Approved);
@@ -126,18 +128,24 @@ fn sub2eth_burn_works() {
         // at this point transfer is in Approved status and are waiting for confirmation
         // from ethereum side to burn. Funds are locked.
 
-        assert_eq!(Balances::reserved_balance(USER2()), amount2);
+        assert_eq!(Balances::reserved_balance(user2()), amount2);
 
-        assert_ok!(Bridge::confirm_transfer(Origin::signed(V2()), sub_message_id));
+        assert_ok!(Bridge::confirm_transfer(
+            Origin::signed(v2()),
+            sub_message_id
+        ));
 
         message = get_message();
         let transfer = Bridge::transfers(1);
         assert_eq!(message.status, Status::Confirmed);
         assert_eq!(transfer.open, true);
-        assert_ok!(Bridge::confirm_transfer(Origin::signed(V1()), sub_message_id));
+        assert_ok!(Bridge::confirm_transfer(
+            Origin::signed(v1()),
+            sub_message_id
+        ));
         // assert_ok!(Bridge::confirm_transfer(Origin::signed(USER1()), sub_message_id));
         //BurnedMessage(Hash, AccountId, H160, u64) event emitted
-        assert_eq!(Balances::free_balance(USER2()), balance_of_user2 - amount2);
+        assert_eq!(Balances::free_balance(user2()), balance_of_user2 - amount2);
         assert_eq!(Balances::total_issuance(), total_issuance - amount2);
     })
 }
@@ -150,7 +158,7 @@ fn sub2eth_burn_skipped_approval_should_fail() {
 
         //substrate ----> ETH
         assert_ok!(Bridge::set_transfer(
-            Origin::signed(USER2()),
+            Origin::signed(user2()),
             eth_address,
             amount2
         ));
@@ -160,11 +168,11 @@ fn sub2eth_burn_skipped_approval_should_fail() {
         let message = Bridge::messages(sub_message_id);
         assert_eq!(message.status, Status::Withdraw);
 
-        assert_eq!(Balances::reserved_balance(USER2()), 0);
+        assert_eq!(Balances::reserved_balance(user2()), 0);
         // lets say validators blacked out and we
         // try to confirm without approval anyway
         assert_noop!(
-            Bridge::confirm_transfer(Origin::signed(V1()), sub_message_id),
+            Bridge::confirm_transfer(Origin::signed(v1()), sub_message_id),
             "This transfer must be approved first."
         );
     })
@@ -178,19 +186,31 @@ fn sub2eth_burn_cancel_works() {
 
         //substrate ----> ETH
         assert_ok!(Bridge::set_transfer(
-            Origin::signed(USER2()),
+            Origin::signed(user2()),
             eth_address,
             amount2
         ));
 
         let sub_message_id = Bridge::message_id_by_transfer_id(0);
-        assert_ok!(Bridge::approve_transfer(Origin::signed(V1()), sub_message_id));
-        assert_ok!(Bridge::approve_transfer(Origin::signed(V2()), sub_message_id));
+        assert_ok!(Bridge::approve_transfer(
+            Origin::signed(v1()),
+            sub_message_id
+        ));
+        assert_ok!(Bridge::approve_transfer(
+            Origin::signed(v2()),
+            sub_message_id
+        ));
         let mut message = Bridge::messages(sub_message_id);
         // funds are locked and waiting for confirmation
         assert_eq!(message.status, Status::Approved);
-        assert_ok!(Bridge::cancel_transfer(Origin::signed(V2()), sub_message_id));
-        assert_ok!(Bridge::cancel_transfer(Origin::signed(V3()), sub_message_id));
+        assert_ok!(Bridge::cancel_transfer(
+            Origin::signed(v2()),
+            sub_message_id
+        ));
+        assert_ok!(Bridge::cancel_transfer(
+            Origin::signed(v3()),
+            sub_message_id
+        ));
         message = Bridge::messages(sub_message_id);
         assert_eq!(message.status, Status::Canceled);
     })
@@ -202,12 +222,12 @@ fn burn_cancel_should_fail() {
         let eth_address = H160::from(ETH_ADDRESS);
         let amount2 = 49;
 
-        let balance_of_user2 = Balances::free_balance(USER2());
+        let balance_of_user2 = Balances::free_balance(user2());
         let total_issuance = Balances::total_issuance();
 
         //substrate ----> ETH
         assert_ok!(Bridge::set_transfer(
-            Origin::signed(USER2()),
+            Origin::signed(user2()),
             eth_address,
             amount2
         ));
@@ -219,33 +239,45 @@ fn burn_cancel_should_fail() {
         assert_eq!(message.status, Status::Withdraw);
 
         //approval
-        assert_eq!(Balances::reserved_balance(USER2()), 0);
-        assert_ok!(Bridge::approve_transfer(Origin::signed(V1()), sub_message_id));
-        assert_ok!(Bridge::approve_transfer(Origin::signed(V2()), sub_message_id));
+        assert_eq!(Balances::reserved_balance(user2()), 0);
+        assert_ok!(Bridge::approve_transfer(
+            Origin::signed(v1()),
+            sub_message_id
+        ));
+        assert_ok!(Bridge::approve_transfer(
+            Origin::signed(v2()),
+            sub_message_id
+        ));
 
         message = get_message();
         assert_eq!(message.status, Status::Approved);
 
         // at this point transfer is in Approved status and are waiting for confirmation
         // from ethereum side to burn. Funds are locked.
-        assert_eq!(Balances::reserved_balance(USER2()), amount2);
-        assert_eq!(Balances::free_balance(USER2()), balance_of_user2 - amount2);
+        assert_eq!(Balances::reserved_balance(user2()), amount2);
+        assert_eq!(Balances::free_balance(user2()), balance_of_user2 - amount2);
         // once it happends, validators call confirm_transfer
 
-        assert_ok!(Bridge::confirm_transfer(Origin::signed(V2()), sub_message_id));
+        assert_ok!(Bridge::confirm_transfer(
+            Origin::signed(v2()),
+            sub_message_id
+        ));
 
         message = get_message();
         let transfer = Bridge::transfers(1);
         assert_eq!(message.status, Status::Confirmed);
         assert_eq!(transfer.open, true);
-        assert_ok!(Bridge::confirm_transfer(Origin::signed(V1()), sub_message_id));
+        assert_ok!(Bridge::confirm_transfer(
+            Origin::signed(v1()),
+            sub_message_id
+        ));
         // assert_ok!(Bridge::confirm_transfer(Origin::signed(USER1()), sub_message_id));
         //BurnedMessage(Hash, AccountId, H160, u64) event emitted
 
-        assert_eq!(Balances::free_balance(USER2()), balance_of_user2 - amount2);
+        assert_eq!(Balances::free_balance(user2()), balance_of_user2 - amount2);
         assert_eq!(Balances::total_issuance(), total_issuance - amount2);
         assert_noop!(
-            Bridge::cancel_transfer(Origin::signed(V2()), sub_message_id),
+            Bridge::cancel_transfer(Origin::signed(v2()), sub_message_id),
             "Failed to cancel. This transfer is already executed."
         );
     })
@@ -258,20 +290,20 @@ fn update_validator_list_should_work() {
         const QUORUM: u64 = 3;
 
         assert_ok!(Bridge::update_validator_list(
-            Origin::signed(V2()),
+            Origin::signed(v2()),
             eth_message_id,
             QUORUM,
-            vec![V1(), V2(), V3(), V4()]
+            vec![v1(), v2(), v3(), v4()]
         ));
         let id = Bridge::message_id_by_transfer_id(0);
         let mut message = Bridge::validator_history(id);
         assert_eq!(message.status, Status::Pending);
 
         assert_ok!(Bridge::update_validator_list(
-            Origin::signed(V1()),
+            Origin::signed(v1()),
             eth_message_id,
             QUORUM,
-            vec![V1(), V2(), V3(), V4()]
+            vec![v1(), v2(), v3(), v4()]
         ));
         message = Bridge::validator_history(id);
         assert_eq!(message.status, Status::Confirmed);
@@ -282,7 +314,7 @@ fn update_validator_list_should_work() {
 #[test]
 fn pause_the_bridge_should_work() {
     new_test_ext().execute_with(|| {
-        assert_ok!(Bridge::pause_bridge(Origin::signed(V2())));
+        assert_ok!(Bridge::pause_bridge(Origin::signed(v2())));
 
         assert_eq!(Bridge::bridge_transfers_count(), 1);
         assert_eq!(Bridge::bridge_is_operational(), true);
@@ -290,7 +322,7 @@ fn pause_the_bridge_should_work() {
         let mut message = Bridge::bridge_messages(id);
         assert_eq!(message.status, Status::Pending);
 
-        assert_ok!(Bridge::pause_bridge(Origin::signed(V1())));
+        assert_ok!(Bridge::pause_bridge(Origin::signed(v1())));
         assert_eq!(Bridge::bridge_is_operational(), false);
         message = Bridge::bridge_messages(id);
         assert_eq!(message.status, Status::Confirmed);
@@ -303,12 +335,18 @@ fn extrinsics_restricted_should_fail() {
         let eth_message_id = H256::from(ETH_MESSAGE_ID);
         let eth_address = H160::from(ETH_ADDRESS);
 
-        assert_ok!(Bridge::pause_bridge(Origin::signed(V2())));
-        assert_ok!(Bridge::pause_bridge(Origin::signed(V1())));
+        assert_ok!(Bridge::pause_bridge(Origin::signed(v2())));
+        assert_ok!(Bridge::pause_bridge(Origin::signed(v1())));
 
         // substrate <-- Ethereum
         assert_noop!(
-            Bridge::multi_signed_mint(Origin::signed(V2()), eth_message_id, eth_address, USER2(), 1000),
+            Bridge::multi_signed_mint(
+                Origin::signed(v2()),
+                eth_message_id,
+                eth_address,
+                user2(),
+                1000
+            ),
             "Bridge is not operational"
         );
     })
@@ -318,11 +356,11 @@ fn extrinsics_restricted_should_fail() {
 fn double_pause_should_fail() {
     new_test_ext().execute_with(|| {
         assert_eq!(Bridge::bridge_is_operational(), true);
-        assert_ok!(Bridge::pause_bridge(Origin::signed(V2())));
-        assert_ok!(Bridge::pause_bridge(Origin::signed(V1())));
+        assert_ok!(Bridge::pause_bridge(Origin::signed(v2())));
+        assert_ok!(Bridge::pause_bridge(Origin::signed(v1())));
         assert_eq!(Bridge::bridge_is_operational(), false);
         assert_noop!(
-            Bridge::pause_bridge(Origin::signed(V1())),
+            Bridge::pause_bridge(Origin::signed(v1())),
             "Bridge is not operational already"
         );
     })
@@ -331,11 +369,11 @@ fn double_pause_should_fail() {
 fn pause_and_resume_the_bridge_should_work() {
     new_test_ext().execute_with(|| {
         assert_eq!(Bridge::bridge_is_operational(), true);
-        assert_ok!(Bridge::pause_bridge(Origin::signed(V2())));
-        assert_ok!(Bridge::pause_bridge(Origin::signed(V1())));
+        assert_ok!(Bridge::pause_bridge(Origin::signed(v2())));
+        assert_ok!(Bridge::pause_bridge(Origin::signed(v1())));
         assert_eq!(Bridge::bridge_is_operational(), false);
-        assert_ok!(Bridge::resume_bridge(Origin::signed(V1())));
-        assert_ok!(Bridge::resume_bridge(Origin::signed(V2())));
+        assert_ok!(Bridge::resume_bridge(Origin::signed(v1())));
+        assert_ok!(Bridge::resume_bridge(Origin::signed(v2())));
         assert_eq!(Bridge::bridge_is_operational(), true);
     })
 }
@@ -344,9 +382,9 @@ fn pause_and_resume_the_bridge_should_work() {
 fn double_vote_should_fail() {
     new_test_ext().execute_with(|| {
         assert_eq!(Bridge::bridge_is_operational(), true);
-        assert_ok!(Bridge::pause_bridge(Origin::signed(V2())));
+        assert_ok!(Bridge::pause_bridge(Origin::signed(v2())));
         assert_noop!(
-            Bridge::pause_bridge(Origin::signed(V2())),
+            Bridge::pause_bridge(Origin::signed(v2())),
             "This validator has already voted."
         );
     })
@@ -362,22 +400,22 @@ fn instant_withdraw_should_fail() {
 
         //substrate <----- ETH
         assert_ok!(Bridge::multi_signed_mint(
-            Origin::signed(V2()),
+            Origin::signed(v2()),
             eth_message_id,
             eth_address,
-            USER3(),
+            user3(),
             amount1
         ));
         assert_ok!(Bridge::multi_signed_mint(
-            Origin::signed(V1()),
+            Origin::signed(v1()),
             eth_message_id,
             eth_address,
-            USER3(),
+            user3(),
             amount1
         ));
         //substrate ----> ETH
         assert_ok!(Bridge::set_transfer(
-            Origin::signed(USER3()),
+            Origin::signed(user3()),
             eth_address,
             amount2
         ));
@@ -387,11 +425,14 @@ fn instant_withdraw_should_fail() {
         let mut message = get_message();
         assert_eq!(message.status, Status::Withdraw);
         //approval
-        assert_eq!(Balances::reserved_balance(USER3()), 0);
-        assert_ok!(Bridge::approve_transfer(Origin::signed(V1()), sub_message_id));
+        assert_eq!(Balances::reserved_balance(user3()), 0);
+        assert_ok!(Bridge::approve_transfer(
+            Origin::signed(v1()),
+            sub_message_id
+        ));
 
         assert_eq!(
-            Bridge::approve_transfer(Origin::signed(V2()), sub_message_id),
+            Bridge::approve_transfer(Origin::signed(v2()), sub_message_id),
             Err(DispatchErrorWithPostInfo::from(
                 "Cannot withdraw more that 75% of first day deposit."
             ))
@@ -413,7 +454,7 @@ fn change_limits_should_work() {
 
         assert_eq!(Bridge::current_limits().max_tx_value, 100);
         assert_ok!(Bridge::update_limits(
-            Origin::signed(V2()),
+            Origin::signed(v2()),
             max_tx_value,
             day_max_limit,
             day_max_limit_for_one_address,
@@ -421,7 +462,7 @@ fn change_limits_should_work() {
             min_tx_value,
         ));
         assert_ok!(Bridge::update_limits(
-            Origin::signed(V1()),
+            Origin::signed(v1()),
             max_tx_value,
             day_max_limit,
             day_max_limit_for_one_address,
@@ -443,7 +484,7 @@ fn change_limits_should_fail() {
 
         assert_noop!(
             Bridge::update_limits(
-                Origin::signed(V1()),
+                Origin::signed(v1()),
                 MORE_THAN_MAX,
                 day_max_limit,
                 day_max_limit_for_one_address,
@@ -463,81 +504,105 @@ fn pending_burn_limit_should_work() {
         let amount2 = 49;
         //TODO: pending transactions volume never reached if daily limit is lower
         // USER1(), USER2() init in mock.rs
-        let _ = Balances::transfer(Origin::signed(USER1()), USER3(), amount1);
-        let _ = Balances::transfer(Origin::signed(USER1()), USER4(), amount1);
-        let _ = Balances::transfer(Origin::signed(USER1()), USER5(), amount1);
-        let _ = Balances::transfer(Origin::signed(USER1()), USER6(), amount1);
-        let _ = Balances::transfer(Origin::signed(USER1()), USER7(), amount1);
-        let _ = Balances::transfer(Origin::signed(USER1()), USER8(), amount1);
-        let _ = Balances::transfer(Origin::signed(USER1()), USER9(), amount1);
+        let _ = Balances::transfer(Origin::signed(user1()), user3(), amount1);
+        let _ = Balances::transfer(Origin::signed(user1()), user4(), amount1);
+        let _ = Balances::transfer(Origin::signed(user1()), user5(), amount1);
+        let _ = Balances::transfer(Origin::signed(user1()), user6(), amount1);
+        let _ = Balances::transfer(Origin::signed(user1()), user7(), amount1);
+        let _ = Balances::transfer(Origin::signed(user1()), user8(), amount1);
+        let _ = Balances::transfer(Origin::signed(user1()), user9(), amount1);
         //1
         assert_ok!(Bridge::set_transfer(
-            Origin::signed(USER2()),
+            Origin::signed(user2()),
             eth_address,
             amount2
         ));
         let sub_message_id = Bridge::message_id_by_transfer_id(0);
-        assert_ok!(Bridge::approve_transfer(Origin::signed(V1()), sub_message_id));
+        assert_ok!(Bridge::approve_transfer(
+            Origin::signed(v1()),
+            sub_message_id
+        ));
 
         assert_ok!(Bridge::set_transfer(
-            Origin::signed(USER3()),
+            Origin::signed(user3()),
             eth_address,
             amount2
         ));
         let sub_message_id = Bridge::message_id_by_transfer_id(1);
-        assert_ok!(Bridge::approve_transfer(Origin::signed(V1()), sub_message_id));
+        assert_ok!(Bridge::approve_transfer(
+            Origin::signed(v1()),
+            sub_message_id
+        ));
 
         assert_ok!(Bridge::set_transfer(
-            Origin::signed(USER4()),
+            Origin::signed(user4()),
             eth_address,
             amount2
         ));
         let sub_message_id = Bridge::message_id_by_transfer_id(2);
-        assert_ok!(Bridge::approve_transfer(Origin::signed(V1()), sub_message_id));
+        assert_ok!(Bridge::approve_transfer(
+            Origin::signed(v1()),
+            sub_message_id
+        ));
 
         assert_ok!(Bridge::set_transfer(
-            Origin::signed(USER5()),
+            Origin::signed(user5()),
             eth_address,
             amount2
         ));
         let sub_message_id = Bridge::message_id_by_transfer_id(3);
-        assert_ok!(Bridge::approve_transfer(Origin::signed(V1()), sub_message_id));
+        assert_ok!(Bridge::approve_transfer(
+            Origin::signed(v1()),
+            sub_message_id
+        ));
 
         assert_ok!(Bridge::set_transfer(
-            Origin::signed(USER6()),
+            Origin::signed(user6()),
             eth_address,
             amount2
         ));
         let sub_message_id = Bridge::message_id_by_transfer_id(4);
-        assert_ok!(Bridge::approve_transfer(Origin::signed(V1()), sub_message_id));
+        assert_ok!(Bridge::approve_transfer(
+            Origin::signed(v1()),
+            sub_message_id
+        ));
 
         assert_ok!(Bridge::set_transfer(
-            Origin::signed(USER7()),
+            Origin::signed(user7()),
             eth_address,
             amount2
         ));
         let sub_message_id = Bridge::message_id_by_transfer_id(5);
-        assert_ok!(Bridge::approve_transfer(Origin::signed(V1()), sub_message_id));
+        assert_ok!(Bridge::approve_transfer(
+            Origin::signed(v1()),
+            sub_message_id
+        ));
 
         assert_ok!(Bridge::set_transfer(
-            Origin::signed(USER8()),
+            Origin::signed(user8()),
             eth_address,
             amount2
         ));
         let sub_message_id = Bridge::message_id_by_transfer_id(6);
-        assert_ok!(Bridge::approve_transfer(Origin::signed(V1()), sub_message_id));
+        assert_ok!(Bridge::approve_transfer(
+            Origin::signed(v1()),
+            sub_message_id
+        ));
 
         assert_ok!(Bridge::set_transfer(
-            Origin::signed(USER9()),
+            Origin::signed(user9()),
             eth_address,
             amount2
         ));
         let sub_message_id = Bridge::message_id_by_transfer_id(7);
-        assert_ok!(Bridge::approve_transfer(Origin::signed(V1()), sub_message_id));
+        assert_ok!(Bridge::approve_transfer(
+            Origin::signed(v1()),
+            sub_message_id
+        ));
 
         assert_eq!(Bridge::pending_burn_count(), amount2 * 8);
         assert_noop!(
-            Bridge::set_transfer(Origin::signed(USER1()), eth_address, amount2),
+            Bridge::set_transfer(Origin::signed(user1()), eth_address, amount2),
             "Too many pending burn transactions."
         );
     })
@@ -560,69 +625,69 @@ fn pending_mint_limit_should_work() {
 
         //substrate <----- ETH
         assert_ok!(Bridge::multi_signed_mint(
-            Origin::signed(V2()),
+            Origin::signed(v2()),
             eth_message_id,
             eth_address,
-            USER2(),
+            user2(),
             amount1
         ));
 
         //substrate <----- ETH
         assert_ok!(Bridge::multi_signed_mint(
-            Origin::signed(V2()),
+            Origin::signed(v2()),
             eth_message_id2,
             eth_address,
-            USER3(),
+            user3(),
             amount1
         ));
 
         //substrate <----- ETH
         assert_ok!(Bridge::multi_signed_mint(
-            Origin::signed(V2()),
+            Origin::signed(v2()),
             eth_message_id3,
             eth_address,
-            USER4(),
+            user4(),
             amount1
         ));
 
         //substrate <----- ETH
         assert_ok!(Bridge::multi_signed_mint(
-            Origin::signed(V2()),
+            Origin::signed(v2()),
             eth_message_id4,
             eth_address,
-            USER5(),
+            user5(),
             amount1
         ));
         //substrate <----- ETH
         assert_ok!(Bridge::multi_signed_mint(
-            Origin::signed(V2()),
+            Origin::signed(v2()),
             eth_message_id5,
             eth_address,
-            USER6(),
+            user6(),
             amount1
         ));
         //substrate <----- ETH
         assert_ok!(Bridge::multi_signed_mint(
-            Origin::signed(V2()),
+            Origin::signed(v2()),
             eth_message_id6,
             eth_address,
-            USER7(),
+            user7(),
             amount1
         ));
         //substrate <----- ETH
         assert_ok!(Bridge::multi_signed_mint(
-            Origin::signed(V2()),
+            Origin::signed(v2()),
             eth_message_id7,
             eth_address,
-            USER8(),
+            user8(),
             amount1
         ));
         //substrate <----- ETH
         assert_ok!(Bridge::multi_signed_mint(
-            Origin::signed(V2()),
+            Origin::signed(v2()),
             eth_message_id8,
             eth_address,
-            USER9(),
+            user9(),
             amount1
         ));
         assert_eq!(Bridge::pending_mint_count(), amount1 * 8);
@@ -630,10 +695,10 @@ fn pending_mint_limit_should_work() {
         //substrate <----- ETH
         assert_noop!(
             Bridge::multi_signed_mint(
-                Origin::signed(V2()),
+                Origin::signed(v2()),
                 eth_message_id1,
                 eth_address,
-                USER1(),
+                user1(),
                 amount1 + 5
             ),
             "Too many pending mint transactions."
@@ -650,30 +715,36 @@ fn blocking_account_by_volume_should_work() {
         let amount3 = 101;
 
         assert_eq!(
-            Bridge::set_transfer(Origin::signed(USER2()), eth_address, amount1),
+            Bridge::set_transfer(Origin::signed(user2()), eth_address, amount1),
             Err(DispatchErrorWithPostInfo::from(
                 "Invalid amount for transaction. Reached minimum limit."
             ))
         );
 
         assert_eq!(
-            Bridge::set_transfer(Origin::signed(USER2()), eth_address, amount3),
+            Bridge::set_transfer(Origin::signed(user2()), eth_address, amount3),
             Err(DispatchErrorWithPostInfo::from(
                 "Invalid amount for transaction. Reached maximum limit."
             ))
         );
 
         assert_ok!(Bridge::set_transfer(
-            Origin::signed(USER2()),
+            Origin::signed(user2()),
             eth_address,
             amount2
         ));
         let sub_message_id = Bridge::message_id_by_transfer_id(0);
-        assert_ok!(Bridge::approve_transfer(Origin::signed(V1()), sub_message_id));
-        assert_ok!(Bridge::approve_transfer(Origin::signed(V2()), sub_message_id));
+        assert_ok!(Bridge::approve_transfer(
+            Origin::signed(v1()),
+            sub_message_id
+        ));
+        assert_ok!(Bridge::approve_transfer(
+            Origin::signed(v2()),
+            sub_message_id
+        ));
 
         assert_eq!(
-            Bridge::set_transfer(Origin::signed(USER2()), eth_address, amount2),
+            Bridge::set_transfer(Origin::signed(user2()), eth_address, amount2),
             Err(DispatchErrorWithPostInfo::from(
                 "Transfer declined, user blocked due to daily volume limit."
             ))
@@ -689,22 +760,28 @@ fn blocked_account_unblocked_next_day_should_work() {
         run_to_block(DAY_IN_BLOCKS.into());
 
         assert_ok!(Bridge::set_transfer(
-            Origin::signed(USER2()),
+            Origin::signed(user2()),
             eth_address,
             amount2
         ));
         let sub_message_id = Bridge::message_id_by_transfer_id(0);
-        assert_ok!(Bridge::approve_transfer(Origin::signed(V1()), sub_message_id));
-        assert_ok!(Bridge::approve_transfer(Origin::signed(V2()), sub_message_id));
+        assert_ok!(Bridge::approve_transfer(
+            Origin::signed(v1()),
+            sub_message_id
+        ));
+        assert_ok!(Bridge::approve_transfer(
+            Origin::signed(v2()),
+            sub_message_id
+        ));
         assert_eq!(
-            Bridge::set_transfer(Origin::signed(USER2()), eth_address, amount2),
+            Bridge::set_transfer(Origin::signed(user2()), eth_address, amount2),
             Err(DispatchErrorWithPostInfo::from(
                 "Transfer declined, user blocked due to daily volume limit."
             ))
         );
 
         //user added to blocked vec
-        let blocked_vec: Vec<sr25519::Public> = vec![USER2()];
+        let blocked_vec: Vec<sr25519::Public> = vec![user2()];
         assert_eq!(Bridge::daily_blocked(1), blocked_vec);
 
         run_to_block((DAY_IN_BLOCKS * 2).into());
@@ -712,7 +789,7 @@ fn blocked_account_unblocked_next_day_should_work() {
 
         //try again
         assert_ok!(Bridge::set_transfer(
-            Origin::signed(USER2()),
+            Origin::signed(user2()),
             eth_address,
             amount2
         ));

--- a/pallets/bridge/src/tests.rs
+++ b/pallets/bridge/src/tests.rs
@@ -1,6 +1,9 @@
 use crate::{mock::*, types::Status};
 use frame_support::{assert_noop, assert_ok, dispatch::DispatchErrorWithPostInfo};
-use sp_core::{sr25519, H160, H256};
+use sp_core::{
+    offchain::{testing, OffchainExt},
+    sr25519, H160, H256,
+};
 
 const DAY_IN_BLOCKS: u32 = 14_400;
 
@@ -794,4 +797,17 @@ fn blocked_account_unblocked_next_day_should_work() {
             amount2
         ));
     })
+}
+
+#[test]
+fn test_get_eth_logs_lock() {
+    let (offchain, _) = testing::TestOffchainExt::new();
+    let mut t = sp_io::TestExternalities::default();
+    t.register_extension(OffchainExt::new(offchain));
+
+    t.execute_with(|| {
+        let (_, filter_id) = Bridge::get_eth_logs_lock("abc".as_bytes().to_vec()).unwrap();
+
+        assert_eq!("abc".as_bytes().to_vec(), filter_id);
+    });
 }

--- a/pallets/bridge/src/weights.rs
+++ b/pallets/bridge/src/weights.rs
@@ -46,6 +46,7 @@ use sp_std::marker::PhantomData;
 
 /// Weight functions needed for pallet_eth_sub_bridge.
 pub trait WeightInfo {
+    fn submit_logs() -> Weight;
     fn set_transfer() -> Weight;
     fn multi_signed_mint() -> Weight;
     fn update_limits() -> Weight;
@@ -60,6 +61,11 @@ pub trait WeightInfo {
 /// Weights for pallet_eth_sub_bridge using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
+    fn submit_logs() -> Weight {
+        (108_413_000 as Weight)
+            .saturating_add(T::DbWeight::get().reads(8 as Weight))
+            .saturating_add(T::DbWeight::get().writes(6 as Weight))
+    }
     fn set_transfer() -> Weight {
         (108_414_000 as Weight)
             .saturating_add(T::DbWeight::get().reads(8 as Weight))
@@ -109,6 +115,11 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 
 // For backwards compatibility and tests
 impl WeightInfo for () {
+    fn submit_logs() -> Weight {
+        (108_413_000 as Weight)
+            .saturating_add(RocksDbWeight::get().reads(8 as Weight))
+            .saturating_add(RocksDbWeight::get().writes(6 as Weight))
+    }
     fn set_transfer() -> Weight {
         (108_414_000 as Weight)
             .saturating_add(RocksDbWeight::get().reads(8 as Weight))

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -48,7 +48,7 @@ pallet-assets = { git = "https://github.com/paritytech/substrate", tag = "v3.0.0
 pallet-authority-discovery = { git = "https://github.com/paritytech/substrate", tag = "v3.0.0", default-features = false }
 pallet-authorship = { git = "https://github.com/paritytech/substrate", tag = "v3.0.0", default-features = false }
 pallet-babe = { git = "https://github.com/paritytech/substrate", tag = "v3.0.0", default-features = false }
-pallet-balances = { version = "3.0.0", path = "../pallets/balances" , default-features = false }
+pallet-balances = { version = "3.0.0", path = "../pallets/balances", default-features = false }
 pallet-bounties = { git = "https://github.com/paritytech/substrate", tag = "v3.0.0", default-features = false }
 pallet-collective = { git = "https://github.com/paritytech/substrate", tag = "v3.0.0", default-features = false}
 pallet-contracts = { git = "https://github.com/paritytech/substrate", tag = "v3.0.0", default-features = false}
@@ -159,7 +159,7 @@ std = [
 	"pallet-credit/std",
 	"pallet-eth-sub-bridge/std",
 	"pallet-deeper-node/std",
-	"pallet-credit-accumulation/std"
+	"pallet-credit-accumulation/std",
 ]
 runtime-benchmarks = [
 	"frame-benchmarking",

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -75,6 +75,7 @@ use sp_version::RuntimeVersion;
 use static_assertions::const_assert;
 
 pub use pallet_micropayment;
+pub use pallet_eth_sub_bridge;
 
 #[cfg(any(feature = "std", test))]
 pub use frame_system::Call as SystemCall;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1059,6 +1059,7 @@ impl pallet_eth_sub_bridge::Config for Runtime {
     type BlocksPerEra = BlocksPerEra;
     type Call = Call;
     type AuthorityId = pallet_eth_sub_bridge::sr25519::AuthorityId;
+    type EthClient = pallet_eth_sub_bridge::ethereum::MockEthClient;
 }
 
 impl pallet_deeper_node::Config for Runtime {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1058,7 +1058,7 @@ impl pallet_eth_sub_bridge::Config for Runtime {
     type WeightInfo = pallet_eth_sub_bridge::weights::SubstrateWeight<Runtime>;
     type BlocksPerEra = BlocksPerEra;
     type Call = Call;
-    type AuthorityId = pallet_eth_sub_bridge::crypto::TestAuthId;
+    type AuthorityId = pallet_eth_sub_bridge::sr25519::AuthorityId;
 }
 
 impl pallet_deeper_node::Config for Runtime {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1051,6 +1051,13 @@ parameter_types! {
     pub const MaxIpLength: usize = 256;
 }
 
+impl pallet_eth_sub_bridge::Config for Runtime {
+    type Event = Event;
+    type Currency = Balances;
+    type WeightInfo = pallet_eth_sub_bridge::weights::SubstrateWeight<Runtime>;
+    type BlocksPerEra = BlocksPerEra;
+}
+
 impl pallet_deeper_node::Config for Runtime {
     type Event = Event;
     type Currency = Balances;
@@ -1135,6 +1142,7 @@ construct_runtime!(
         Micropayment: pallet_micropayment::{Module, Call, Storage, Event<T>},
         DeeperNode: pallet_deeper_node::{Module, Call, Storage, Event<T>, Config<T> },
         CreditAccumulation: pallet_credit_accumulation::{Module, Call, Storage, Event<T>},
+        Bridge: pallet_eth_sub_bridge::{Module, Call, Storage, Event<T>},
     }
 );
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -74,8 +74,8 @@ use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 use static_assertions::const_assert;
 
-pub use pallet_micropayment;
 pub use pallet_eth_sub_bridge;
+pub use pallet_micropayment;
 
 #[cfg(any(feature = "std", test))]
 pub use frame_system::Call as SystemCall;
@@ -1059,7 +1059,7 @@ impl pallet_eth_sub_bridge::Config for Runtime {
     type BlocksPerEra = BlocksPerEra;
     type Call = Call;
     type AuthorityId = pallet_eth_sub_bridge::sr25519::AuthorityId;
-    type EthClient = pallet_eth_sub_bridge::ethereum::MockEthClient;
+    type EthClient = pallet_eth_sub_bridge::ethereum::RealEthClient;
 }
 
 impl pallet_deeper_node::Config for Runtime {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1056,6 +1056,8 @@ impl pallet_eth_sub_bridge::Config for Runtime {
     type Currency = Balances;
     type WeightInfo = pallet_eth_sub_bridge::weights::SubstrateWeight<Runtime>;
     type BlocksPerEra = BlocksPerEra;
+    type Call = Call;
+    type AuthorityId = pallet_eth_sub_bridge::crypto::TestAuthId;
 }
 
 impl pallet_deeper_node::Config for Runtime {


### PR DESCRIPTION
Traditional cross chain tech requires a centralized  relay to sync data from ethereum to substrate, this pull request create  a distributed cross chain bridge by running the relay inside each validator node as an offchain_worker. These offchain workers sync ethereum data and submit to substrate blockchain, with these trusted proofs, we can deposit to any account.

To achieve this goal, several steps needs to be done.

- [x] Complete offchain worker to sync logs from ethereum.
- [x] Verify these logs and submit to blockchain
- [ ] Trigger a transfer when a transfer event was synced from ethereum.