### PR TITLE
client can close channel when server is offline longer than 1 era

### DIFF
--- a/pallets/micropayment/src/lib.rs
+++ b/pallets/micropayment/src/lib.rs
@@ -56,6 +56,7 @@ pub mod pallet {
     use log::error;
     use pallet_balances::MutableCurrency;
     use pallet_credit::CreditInterface;
+    use pallet_deeper_node::NodeInterface;
     use sp_core::sr25519;
     use sp_io::crypto::sr25519_verify;
     use sp_runtime::traits::{Saturating, StoredMapError, Zero};
@@ -76,6 +77,8 @@ pub mod pallet {
         type AccountCreator: AccountCreator<Self::AccountId>;
         // Weight information for extrinsics in this pallet.
         type WeightInfo: WeightInfo;
+        /// NodeInterface of deeper-node pallet
+        type NodeInterface: NodeInterface<Self::AccountId, Self::BlockNumber>;
     }
 
     type BalanceOf<T> =
@@ -262,7 +265,9 @@ pub mod pallet {
                 // signer is client
                 let chan = Channel::<T>::get(&signer, &account_id);
                 let current_block = <frame_system::Module<T>>::block_number();
-                if chan.expiration < current_block {
+                if chan.expiration < current_block
+                    || T::NodeInterface::get_eras_offline(&chan.server) >= 1
+                {
                     TotalMicropaymentChannelBalance::<T>::mutate_exists(&signer, |b| {
                         let total_balance = b.take().unwrap_or_default();
                         *b = if total_balance > chan.balance {

--- a/pallets/micropayment/src/mock.rs
+++ b/pallets/micropayment/src/mock.rs
@@ -98,7 +98,7 @@ const MILLISECS_PER_BLOCK: Moment = 5000;
 const SECS_PER_BLOCK: Moment = MILLISECS_PER_BLOCK / 1000;
 const EPOCH_DURATION_IN_BLOCKS: BlockNumber = 60 / (SECS_PER_BLOCK as BlockNumber);
 const CREDIT_ATTENUATION_STEP: u64 = 1;
-const BLOCKS_PER_ERA: BlockNumber = 6 * EPOCH_DURATION_IN_BLOCKS;
+pub const BLOCKS_PER_ERA: BlockNumber = 6 * EPOCH_DURATION_IN_BLOCKS;
 
 parameter_types! {
     pub const CreditCapTwoEras: u8 = 5;
@@ -155,6 +155,7 @@ impl pallet_micropayment::Config for Test {
     type DataPerDPR = DataPerDPR;
     type AccountCreator = TestAccountCreator;
     type WeightInfo = ();
+    type NodeInterface = DeeperNode;
 }
 
 // Build genesis storage according to the mock runtime.

--- a/pallets/staking/src/mock.rs
+++ b/pallets/staking/src/mock.rs
@@ -188,6 +188,7 @@ impl pallet_micropayment::Config for Test {
     type DataPerDPR = DataPerDPR;
     type AccountCreator = TestAccountCreator;
     type WeightInfo = ();
+    type NodeInterface = DeeperNode;
 }
 
 parameter_types! {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1042,6 +1042,7 @@ impl pallet_micropayment::Config for Runtime {
     type DataPerDPR = DataPerDPR;
     type AccountCreator = DefaultAccountCreator;
     type WeightInfo = pallet_micropayment::weights::SubstrateWeight<Runtime>;
+    type NodeInterface = DeeperNode;
 }
 
 parameter_types! {


### PR DESCRIPTION
In the previous logic, client can close a channel only if the channel is expired. To prevent micropayment channel from locking too much money, if a server if offline for a long time, let's say 1 era, then the client should be able to close this channel.