### PR TITLE
Some changes related to events in the credit pallet.

### DIFF
--- a/pallets/credit/src/lib.rs
+++ b/pallets/credit/src/lib.rs
@@ -240,11 +240,13 @@ pub mod pallet {
     #[pallet::metadata(T::AccountId = "AccountId")]
     #[pallet::generate_deposit(pub(super) fn deposit_event)]
     pub enum Event<T: Config> {
-        CreditUpdateSuccess(T::AccountId, u64),
-        CreditUpdateFailed(T::AccountId, u64),
-        CreditSettingUpdated(CreditSetting<BalanceOf<T>>),
-        CreditDataAdded(T::AccountId, CreditData),
-        CreditDataUpdated(T::AccountId, CreditData),
+        CreditUpdateSuccess(T::AccountId, u64, T::BlockNumber),
+        CreditUpdateFailed(T::AccountId, u64, T::BlockNumber),
+        CreditSettingUpdated(CreditSetting<BalanceOf<T>>, T::BlockNumber),
+        CreditDataAdded(T::AccountId, CreditData, T::BlockNumber),
+        CreditDataUpdated(T::AccountId, CreditData, T::BlockNumber),
+        CreditScoreIncreased(T::AccountId, u64, T::BlockNumber),
+        CreditScoreSlashed(T::AccountId, u64, T::BlockNumber),
     }
 
     #[pallet::error]
@@ -271,7 +273,10 @@ pub mod pallet {
         ) -> DispatchResultWithPostInfo {
             ensure_root(origin)?; // requires sudo
             Self::_update_credit_setting(credit_setting.clone());
-            Self::deposit_event(Event::CreditSettingUpdated(credit_setting));
+            Self::deposit_event(Event::CreditSettingUpdated(
+                credit_setting,
+                <frame_system::Module<T>>::block_number(),
+            ));
             Ok(().into())
         }
 
@@ -285,6 +290,7 @@ pub mod pallet {
             ensure_root(origin)?;
             Self::check_credit_data(&credit_data)?;
 
+            let current_block_numbers = <frame_system::Module<T>>::block_number();
             if UserCredit::<T>::contains_key(&account_id) {
                 UserCredit::<T>::mutate(&account_id, |d| match d {
                     Some(data) => *data = credit_data.clone(),
@@ -293,10 +299,18 @@ pub mod pallet {
                 if !Self::user_credit_history(&account_id).is_empty() {
                     Self::update_credit_history(&account_id, Self::get_current_era());
                 }
-                Self::deposit_event(Event::CreditDataUpdated(account_id, credit_data));
+                Self::deposit_event(Event::CreditDataUpdated(
+                    account_id,
+                    credit_data,
+                    current_block_numbers,
+                ));
             } else {
                 UserCredit::<T>::insert(&account_id, credit_data.clone());
-                Self::deposit_event(Event::CreditDataAdded(account_id, credit_data));
+                Self::deposit_event(Event::CreditDataAdded(
+                    account_id,
+                    credit_data,
+                    current_block_numbers,
+                ));
             }
             Ok(().into())
         }
@@ -315,6 +329,7 @@ pub mod pallet {
 
         /// inner: update credit score
         fn _update_credit(account_id: &T::AccountId, score: u64) -> bool {
+            let current_block_numbers = <frame_system::Module<T>>::block_number();
             if UserCredit::<T>::contains_key(account_id) {
                 UserCredit::<T>::mutate(account_id, |v| match v {
                     Some(credit_data) => {
@@ -323,10 +338,18 @@ pub mod pallet {
                     }
                     _ => (),
                 });
-                Self::deposit_event(Event::CreditUpdateSuccess((*account_id).clone(), score));
+                Self::deposit_event(Event::CreditUpdateSuccess(
+                    (*account_id).clone(),
+                    score,
+                    current_block_numbers,
+                ));
                 true
             } else {
-                Self::deposit_event(Event::CreditUpdateFailed((*account_id).clone(), score));
+                Self::deposit_event(Event::CreditUpdateFailed(
+                    (*account_id).clone(),
+                    score,
+                    current_block_numbers,
+                ));
                 false
             }
         }
@@ -502,6 +525,13 @@ pub mod pallet {
                         credit_data.credit = credit_data.credit.saturating_sub(penalty);
                         credit_data.current_credit_level =
                             Self::get_credit_level(credit_data.credit);
+
+                        let current_block_numbers = <frame_system::Module<T>>::block_number();
+                        Self::deposit_event(Event::CreditScoreSlashed(
+                            (*account_id).clone(),
+                            (*credit_data).clone().credit,
+                            current_block_numbers,
+                        ));
                     }
                     _ => (),
                 });
@@ -700,6 +730,13 @@ pub mod pallet {
                     if Self::_update_credit(&server_id, new_credit) {
                         LastCreditUpdate::<T>::insert(&server_id, current_era);
                         Self::update_credit_history(&server_id, current_era);
+
+                        let current_block_numbers = <frame_system::Module<T>>::block_number();
+                        Self::deposit_event(Event::CreditScoreIncreased(
+                            server_id,
+                            new_credit,
+                            current_block_numbers,
+                        ));
                     } else {
                         log!(
                             error,
@@ -732,6 +769,13 @@ pub mod pallet {
                 if Self::_update_credit(&server_id, new_credit) {
                     LastCreditUpdate::<T>::insert(&server_id, current_era);
                     Self::update_credit_history(&server_id, current_era);
+
+                    let current_block_numbers = <frame_system::Module<T>>::block_number();
+                    Self::deposit_event(Event::CreditScoreIncreased(
+                        server_id,
+                        new_credit,
+                        current_block_numbers,
+                    ));
                 } else {
                     log!(
                         error,

--- a/pallets/credit/src/lib.rs
+++ b/pallets/credit/src/lib.rs
@@ -526,11 +526,10 @@ pub mod pallet {
                         credit_data.current_credit_level =
                             Self::get_credit_level(credit_data.credit);
 
-                        let current_block_numbers = <frame_system::Module<T>>::block_number();
                         Self::deposit_event(Event::CreditScoreSlashed(
                             (*account_id).clone(),
                             (*credit_data).clone().credit,
-                            current_block_numbers,
+                            <frame_system::Module<T>>::block_number(),
                         ));
                     }
                     _ => (),
@@ -731,11 +730,10 @@ pub mod pallet {
                         LastCreditUpdate::<T>::insert(&server_id, current_era);
                         Self::update_credit_history(&server_id, current_era);
 
-                        let current_block_numbers = <frame_system::Module<T>>::block_number();
                         Self::deposit_event(Event::CreditScoreIncreased(
                             server_id,
                             new_credit,
-                            current_block_numbers,
+                            <frame_system::Module<T>>::block_number(),
                         ));
                     } else {
                         log!(
@@ -770,11 +768,10 @@ pub mod pallet {
                     LastCreditUpdate::<T>::insert(&server_id, current_era);
                     Self::update_credit_history(&server_id, current_era);
 
-                    let current_block_numbers = <frame_system::Module<T>>::block_number();
                     Self::deposit_event(Event::CreditScoreIncreased(
                         server_id,
                         new_credit,
-                        current_block_numbers,
+                        <frame_system::Module<T>>::block_number(),
                     ));
                 } else {
                     log!(


### PR DESCRIPTION
1.  associating block numbers to events to fix  #109 
2. add event for credit score penalty reduction to   fix #100 
3. add event when credit score increases to  fix #104 
