### PR TITLE
Add feature for reward countdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4273,6 +4273,20 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "3.0.0"
+source = "git+https://github.com/paritytech/substrate?tag=v3.0.0#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "serde",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-balances"
+version = "3.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4282,20 +4296,6 @@ dependencies = [
  "serde",
  "sp-core",
  "sp-io",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
-name = "pallet-balances"
-version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?tag=v3.0.0#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
-dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "parity-scale-codec",
- "serde",
  "sp-runtime",
  "sp-std",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4273,20 +4273,6 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?tag=v3.0.0#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
-dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "parity-scale-codec",
- "serde",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
-name = "pallet-balances"
-version = "3.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4296,6 +4282,20 @@ dependencies = [
  "serde",
  "sp-core",
  "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-balances"
+version = "3.0.0"
+source = "git+https://github.com/paritytech/substrate?tag=v3.0.0#49a4103f4bfef55be20a5c6d26e18ff3003c3353"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "serde",
  "sp-runtime",
  "sp-std",
 ]

--- a/pallets/credit/src/lib.rs
+++ b/pallets/credit/src/lib.rs
@@ -313,7 +313,6 @@ pub mod pallet {
                 Self::deposit_event(Event::CreditDataUpdated(account_id, credit_data));
             } else {
                 UserCredit::<T>::insert(&account_id, credit_data.clone());
-                RewardCountdown::<T>::insert(&account_id, credit_data.reward_eras);
                 Self::deposit_event(Event::CreditDataAdded(account_id, credit_data));
             }
             Ok(().into())

--- a/pallets/credit/src/lib.rs
+++ b/pallets/credit/src/lib.rs
@@ -313,6 +313,7 @@ pub mod pallet {
                 Self::deposit_event(Event::CreditDataUpdated(account_id, credit_data));
             } else {
                 UserCredit::<T>::insert(&account_id, credit_data.clone());
+                RewardCountdown::<T>::insert(&account_id, credit_data.reward_eras);
                 Self::deposit_event(Event::CreditDataAdded(account_id, credit_data));
             }
             Ok(().into())
@@ -625,13 +626,12 @@ pub mod pallet {
                 return (None, weight);
             }
 
-            let rewarded_eras = cmp::min(to, expiry_era);
             // update reward remain eras.
-            let reward_remain_eras = expiry_era - rewarded_eras;
+            let reward_remain_eras = expiry_era.saturating_sub(cmp::min(to, expiry_era));
             if reward_remain_eras > 0 {
                 RewardCountdown::<T>::insert(account_id, reward_remain_eras);
             } else {
-                RewardCountdown::<T>::remove(account_id);
+                RewardCountdown::<T>::insert(account_id, 0);
             }
 
             let mut referee_reward = BalanceOf::<T>::zero();

--- a/pallets/credit/src/mock.rs
+++ b/pallets/credit/src/mock.rs
@@ -496,6 +496,18 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
                     reward_eras: 270,
                 },
             ),
+            (
+                12,
+                CreditData {
+                    campaign_id: 1,
+                    credit: 200,
+                    initial_credit_level: CreditLevel::Two,
+                    rank_in_initial_credit_level: 801u32,
+                    number_of_referees: 2,
+                    current_credit_level: CreditLevel::Two,
+                    reward_eras: 270,
+                },
+            ),
         ],
     };
     GenesisBuild::<Test>::assimilate_storage(&genesis_config, &mut storage).unwrap();

--- a/pallets/credit/src/tests.rs
+++ b/pallets/credit/src/tests.rs
@@ -549,3 +549,106 @@ fn slash_offline_devices_credit() {
         assert_eq!(Credit::user_credit(&3).unwrap().credit, 97);
     });
 }
+
+#[test]
+fn reward_remain_eras_count() {
+    new_test_ext().execute_with(|| {
+        // era 0
+        assert_ok!(DeeperNode::im_online(Origin::signed(12)));
+//reward_countdown
+        // era 1
+        run_to_block(BLOCKS_PER_ERA);
+        assert_eq!(Credit::user_credit_history(12), vec![]);
+        Credit::get_reward(&12, 0, 0);
+        let remain_eras = Credit::reward_countdown(12).unwrap_or(0);
+        assert_eq!(remain_eras, 269);
+
+        let credit_historys = vec![(
+            0,
+            CreditData {
+                campaign_id: 1,
+                credit: 200,
+                initial_credit_level: CreditLevel::Two,
+                rank_in_initial_credit_level: 801u32,
+                number_of_referees: 2,
+                current_credit_level: CreditLevel::Two,
+                reward_eras: 270,
+            },
+        )];
+        assert_eq!(Credit::user_credit_history(12), credit_historys);
+
+        // era 10
+        run_to_block(BLOCKS_PER_ERA * 10);
+        Credit::get_reward(&12, 1, 9);
+        let remain_eras = Credit::reward_countdown(12).unwrap_or(0);
+        assert_eq!(remain_eras, 260);
+
+        // era 50
+        run_to_block(BLOCKS_PER_ERA * 50);
+        Credit::get_reward(&12, 10, 49);
+        let remain_eras = Credit::reward_countdown(12).unwrap_or(0);
+        assert_eq!(remain_eras, 220);
+
+        // era 100
+        run_to_block(BLOCKS_PER_ERA * 100);
+        let credit_data = CreditData {
+            campaign_id: 1,
+            credit: 400,
+            initial_credit_level: CreditLevel::Four,
+            rank_in_initial_credit_level: 801u32,
+            number_of_referees: 2,
+            current_credit_level: CreditLevel::Four,
+            reward_eras: 270,
+        };
+
+        assert_ok!(Credit::add_or_update_credit_data(
+            RawOrigin::Root.into(),
+            12,
+            credit_data.clone()
+        ));
+
+        let credit_historys = vec![
+            (
+                0,
+                CreditData {
+                    campaign_id: 1,
+                    credit: 200,
+                    initial_credit_level: CreditLevel::Two,
+                    rank_in_initial_credit_level: 801u32,
+                    number_of_referees: 2,
+                    current_credit_level: CreditLevel::Two,
+                    reward_eras: 270,
+                },
+            ),
+            (
+                100,
+                CreditData {
+                    campaign_id: 1,
+                    credit: 400,
+                    initial_credit_level: CreditLevel::Four,
+                    rank_in_initial_credit_level: 801u32,
+                    number_of_referees: 2,
+                    current_credit_level: CreditLevel::Four,
+                    reward_eras: 270,
+                },
+            ),
+        ];
+        assert_eq!(Credit::user_credit_history(12), credit_historys);
+        let remain_eras = Credit::reward_countdown(12).unwrap_or(0);
+        assert_eq!(remain_eras, 220);
+        Credit::get_reward(&12, 50, 99);
+        let remain_eras = Credit::reward_countdown(12).unwrap_or(0);
+        assert_eq!(remain_eras, 170);
+
+        // era 270
+        run_to_block(BLOCKS_PER_ERA * 270);
+        Credit::get_reward(&12, 100, 269);
+        let remain_eras = Credit::reward_countdown(12).unwrap_or(0);
+        assert_eq!(remain_eras, 0);
+
+        // era 270
+        run_to_block(BLOCKS_PER_ERA * 370);
+        let remain_eras = Credit::reward_countdown(12).unwrap_or(0);
+        assert_eq!(remain_eras, 0);
+    });
+}


### PR DESCRIPTION
fixes #122 

According to the requirements of the marketing department, it is necessary to be able to query the number of eras of campaign remaining for each user.