### PR TITLE
update spec_version:7

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -123,7 +123,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // and set impl_version to 0. If only runtime
     // implementation changes and behavior does not, then leave spec_version as
     // is and increment impl_version.
-    spec_version: 6,
+    spec_version: 7,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 3,


### PR DESCRIPTION
spec_version：7
1. [deeper-chain (based on polkadot-v0.9.12) upgrade](https://github.com/deeper-chain/deeper-chain/pull/134)
2. [Clear errors and warnings when upgrading to 4.0](https://github.com/deeper-chain/deeper-chain/pull/136)
3. [Update pallet's weights](https://github.com/deeper-chain/deeper-chain/pull/138)