### PR TITLE
add integration test ci

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,7 +1,6 @@
 name: bench
 
 on:
-  pull_request:
   push:
     branches:
       - master
@@ -9,7 +8,7 @@ on:
 jobs:
   bench:
     name: benchmark
-    runs-on: [self-hosted]
+    runs-on: [self-hosted, linux, deeper-chain-runner]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,8 +11,14 @@ jobs:
     name: Build
     runs-on: [ubuntu-latest]
     steps:
-      - name: Checkout Repository
+      - name: Checkout Chain Repository
         uses: actions/checkout@master
+
+      - name: Checkout Integration Tests Repository
+        uses: actions/checkout@master
+        with:
+          repository: deeper-chain/integration-tests
+          path: './integration-tests'
 
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
@@ -26,3 +32,17 @@ jobs:
       
       - name: Compile
         run: cargo build
+
+      - name: Install node env
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+
+      - name: start dev chain
+        run: nohup ./target/debug/deeper-chain --dev > /tmp/chain-dev.log &
+
+      - name: run integration tests
+        working-directory: ./integration-tests
+        run: |
+          npm install
+          npm run test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
     name: Unit test
-    runs-on: [self-hosted]
+    runs-on: [self-hosted, linux, deeper-chain-runner]
     env:
       CARGO_INCREMENTAL: 0
       SKIP_BUILD_WASM: true


### PR DESCRIPTION
Changes are:
1. Benchmark only run on merge to master, no need to run twice.
2. Self-hosted machine use a more accurate name
3. After we built a binary, start it in --dev mode and run some integration tests.