### PR TITLE
add clippy check

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,33 @@
+#
+# An auto defined `clippy` feature was introduced,
+# but it was found to clash with user defined features,
+# so was renamed to `cargo-clippy`.
+#
+# If you want standard clippy run:
+# RUSTFLAGS= cargo clippy
+[target.'cfg(feature = "cargo-clippy")']
+rustflags = [
+  "-Aclippy::all",
+  "-Dclippy::correctness",
+  "-Aclippy::if-same-then-else",
+  "-Aclippy::clone-double-ref",
+  "-Dclippy::complexity",
+  "-Aclippy::clone_on_copy",             # Too common
+  "-Aclippy::needless_lifetimes",        # Backward compat?
+  "-Aclippy::zero-prefixed-literal",     # 00_1000_000
+  "-Aclippy::type_complexity",           # raison d'etre
+  "-Aclippy::nonminimal-bool",           # maybe
+  "-Aclippy::borrowed-box",              # Reasonable to fix this one
+  "-Aclippy::too-many-arguments",        # (Turning this on would lead to)
+  "-Aclippy::unnecessary_cast",          # Types may change
+  "-Aclippy::identity-op",               # One case where we do 0 + 
+  "-Aclippy::useless_conversion",        # Types may change
+  "-Aclippy::unit_arg",                  # styalistic.
+  "-Aclippy::option-map-unit-fn",        # styalistic
+  "-Aclippy::bind_instead_of_map",       # styalistic 
+  "-Aclippy::erasing_op",                # E.g. 0 * DOLLARS
+  "-Aclippy::eq_op",                     # In tests we test equality.
+  "-Aclippy::while_immutable_condition", # false positives
+  "-Aclippy::needless_option_as_deref",  # false positives
+  "-Aclippy::derivable_impls",           # false positives
+]

--- a/.github/workflows/style_check.yml
+++ b/.github/workflows/style_check.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@master
 
-      - name: Install Rust toolchain ${{ matrix.rust }}
+      - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
           components: rustfmt, clippy
@@ -26,3 +26,6 @@ jobs:
       
       - name: Cargo Fmt Check
         run: cargo fmt --all -- --check
+
+      - name: Cargo Clippy check
+        run: SKIP_WASM_BUILD=1 env -u RUSTFLAGS cargo clippy --all-targets

--- a/inspect/src/lib.rs
+++ b/inspect/src/lib.rs
@@ -269,7 +269,7 @@ impl<Hash: FromStr + Debug, Number: FromStr + Debug> FromStr for ExtrinsicAddres
 
         let index = it
             .next()
-            .ok_or_else(|| format!("Extrinsic index missing: example \"5:0\""))?
+            .ok_or_else(|| "Extrinsic index missing: example \"5:0\"".to_string())?
             .parse()
             .map_err(|e| format!("Invalid index format: {}", e))?;
 

--- a/pallets/deeper-node/src/lib.rs
+++ b/pallets/deeper-node/src/lib.rs
@@ -209,10 +209,7 @@ pub mod pallet {
             country: CountryRegion,
         ) -> DispatchResultWithPostInfo {
             let sender = ensure_signed(origin)?;
-            ensure!(
-                <RegionMapInit<T>>::get() == true,
-                Error::<T>::InvalidRegionMap
-            );
+            ensure!(<RegionMapInit<T>>::get(), Error::<T>::InvalidRegionMap);
             ensure!(
                 <RegionMap<T>>::contains_key(&country),
                 Error::<T>::InvalidCode
@@ -355,20 +352,18 @@ pub mod pallet {
 
             // country registration
             let mut country_server_list = <ServersByCountry<T>>::get(&node.country);
-            if Self::country_list_insert(
+            if !Self::country_list_insert(
                 &mut country_server_list,
                 &sender,
                 &node.country,
                 &duration,
-            ) == false
-            {
+            ) {
                 Err(Error::<T>::DoubleCountryRegistration)?
             }
 
             // level 3 region registration
             let mut level3_server_list = <ServersByRegion<T>>::get(&first_region);
-            if Self::region_list_insert(&mut level3_server_list, &sender, &first_region, &duration)
-                == false
+            if !Self::region_list_insert(&mut level3_server_list, &sender, &first_region, &duration)
             {
                 let _ = Self::country_list_remove(&mut country_server_list, &sender, &node.country);
                 Err(Error::<T>::DoubleLevel3Registration)?
@@ -376,9 +371,7 @@ pub mod pallet {
 
             // level 2 region registration
             let mut level2_server_list = <ServersByRegion<T>>::get(&sec_region);
-            if Self::region_list_insert(&mut level2_server_list, &sender, &sec_region, &duration)
-                == false
-            {
+            if !Self::region_list_insert(&mut level2_server_list, &sender, &sec_region, &duration) {
                 let _ = Self::country_list_remove(&mut country_server_list, &sender, &node.country);
                 let _ = Self::region_list_remove(&mut level3_server_list, &sender, &first_region);
                 Err(Error::<T>::DoubleLevel2Registration)?

--- a/pallets/staking/src/lib.rs
+++ b/pallets/staking/src/lib.rs
@@ -2430,7 +2430,6 @@ impl<T: Config> pallet::Pallet<T> {
                     Self::candidate_validators(v)
                         .delegators
                         .into_iter()
-                        .map(|d| d)
                         .collect()
                 } else {
                     Vec::new()
@@ -2778,8 +2777,7 @@ where
             match eras
                 .iter()
                 .rev()
-                .filter(|&&(_, ref sesh)| sesh <= &slash_session)
-                .next()
+                .find(|&&(_, ref sesh)| sesh <= &slash_session)
             {
                 Some(&(ref slash_era, _)) => *slash_era,
                 // before bonding period. defensive - should be filtered out.


### PR DESCRIPTION
Polkadot and substrate have added cargo clippy to ci, I think it's good that we catch up with them.
Fixes #97 

lint rules were copied from https://github.com/paritytech/substrate/blob/master/.cargo/config.toml