### PR TITLE
Added evm pallet, need to update transaction_version

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -158,7 +158,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_version: 8,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
-    transaction_version: 3,
+    transaction_version: 4,
 };
 
 /// The BABE epoch configuration at genesis.


### PR DESCRIPTION
An unstable phenomenon occurs during the operation of the testnet node. After inspection, transaction_version should be updated, because construct_runtime! adds EVM pallet inside