### PR TITLE
Remove the eth rpc interface that triggered the panic

### DIFF
--- a/frontier/client/rpc-core/src/eth.rs
+++ b/frontier/client/rpc-core/src/eth.rs
@@ -136,14 +136,6 @@ pub trait EthApi {
     fn transaction_by_block_hash_and_index(&self, _: H256, _: Index)
         -> Result<Option<Transaction>>;
 
-    /// Returns transaction by given block number and index.
-    #[rpc(name = "eth_getTransactionByBlockNumberAndIndex")]
-    fn transaction_by_block_number_and_index(
-        &self,
-        _: BlockNumber,
-        _: Index,
-    ) -> Result<Option<Transaction>>;
-
     /// Returns transaction receipt by transaction hash.
     #[rpc(name = "eth_getTransactionReceipt")]
     fn transaction_receipt(&self, _: H256) -> Result<Option<Receipt>>;


### PR DESCRIPTION
The eth_getTransactionByBlockNumberAndIndex interface call causes a panic, resulting in blockchain nodes dropping out. This interface will be removed until it is fixed