### PR TITLE
fix delegator's first credit history writen

### DIFF
--- a/pallets/credit/src/lib.rs
+++ b/pallets/credit/src/lib.rs
@@ -132,7 +132,6 @@ pub mod pallet {
         weights::Weight,
     };
     use frame_system::pallet_prelude::*;
-    use node_primitives::BlockNumber;
     use pallet_deeper_node::NodeInterface;
     use sp_runtime::{
         traits::{Saturating, Zero},

--- a/pallets/credit/src/tests.rs
+++ b/pallets/credit/src/tests.rs
@@ -165,10 +165,10 @@ fn add_or_update_credit_data_check_credit_history_and_reward() {
     new_test_ext().execute_with(|| {
         // era 0
         assert_ok!(DeeperNode::im_online(Origin::signed(3)));
-
         // era 1
         run_to_block(BLOCKS_PER_ERA);
         assert_eq!(Credit::user_credit_history(3), vec![]);
+        Credit::init_delegator_history(&3, 0);
         assert_eq!(
             Credit::get_reward(&3, 0, 0).0,
             Some((0, 21369858941948251800))
@@ -347,13 +347,13 @@ fn update_credit_by_traffic() {
 #[test]
 fn get_reward_work() {
     new_test_ext().execute_with(|| {
-        assert_ok!(DeeperNode::im_online(Origin::signed(3)));
-        assert_ok!(DeeperNode::im_online(Origin::signed(7)));
-        assert_ok!(DeeperNode::im_online(Origin::signed(8)));
-        assert_ok!(DeeperNode::im_online(Origin::signed(9)));
-        assert_ok!(DeeperNode::im_online(Origin::signed(10)));
-        assert_ok!(DeeperNode::im_online(Origin::signed(11)));
         assert_eq!(Credit::get_reward(&3, 0, 0).0, None);
+        Credit::init_delegator_history(&3, 0);
+        Credit::init_delegator_history(&7, 0);
+        Credit::init_delegator_history(&8, 0);
+        Credit::init_delegator_history(&9, 0);
+        Credit::init_delegator_history(&10, 0);
+        Credit::init_delegator_history(&11, 0);
         run_to_block(BLOCKS_PER_ERA); // era 1
         assert_eq!(
             Credit::get_reward(&3, 0, 0).0,
@@ -410,6 +410,7 @@ fn get_reward_with_update_credit_no_bonus() {
         Timestamp::set_timestamp(INIT_TIMESTAMP);
         assert_ok!(DeeperNode::im_online(Origin::signed(6)));
         assert_eq!(Credit::user_credit(&6).unwrap().credit, 100);
+        Credit::init_delegator_history(&6, 0);
         run_to_block(BLOCKS_PER_ERA);
         assert_eq!(
             Credit::get_reward(&6, 0, 0).0,
@@ -450,6 +451,7 @@ fn get_reward_with_update_credit_with_bonus() {
     new_test_ext().execute_with(|| {
         assert_ok!(DeeperNode::im_online(Origin::signed(7)));
         assert_eq!(Credit::user_credit(&7).unwrap().credit, 400);
+        Credit::init_delegator_history(&7, 0);
         run_to_block(BLOCKS_PER_ERA);
         assert_eq!(
             Credit::get_reward(&7, 0, 0).0,
@@ -488,8 +490,8 @@ fn get_reward_with_update_credit_with_bonus() {
 #[test]
 fn get_reward_with_slash_credit_with_bonus() {
     new_test_ext().execute_with(|| {
-        assert_ok!(DeeperNode::im_online(Origin::signed(7)));
         assert_eq!(Credit::user_credit(&7).unwrap().credit, 400);
+        Credit::init_delegator_history(&7, 0);
         run_to_block(BLOCKS_PER_ERA);
         assert_eq!(
             Credit::get_reward(&7, 0, 0).0,
@@ -565,9 +567,8 @@ fn update_credit_history_when_era_is_the_same() {
                 reward_eras: 270,
             },
         );
-        assert_ok!(DeeperNode::im_online(Origin::signed(1)));
+        Credit::init_delegator_history(&1, 0);
         //default era=0
-        Credit::update_credit_history(&1, 0);
 
         let credit_historys = vec![(
             0,
@@ -604,7 +605,7 @@ fn update_credit_history_when_era_is_non_zero() {
         );
         // run_to_block, era=1
         run_to_block(BLOCKS_PER_ERA);
-        assert_ok!(DeeperNode::im_online(Origin::signed(1)));
+        Credit::init_delegator_history(&1, 1);
         Credit::update_credit_history(&1, 10);
 
         let credit_historys = vec![
@@ -642,27 +643,27 @@ fn update_credit_history_when_era_is_non_zero() {
 fn reward_remain_eras_count() {
     new_test_ext().execute_with(|| {
         // era 0
+        let credit_data = CreditData {
+            campaign_id: 1,
+            credit: 200,
+            initial_credit_level: CreditLevel::Two,
+            rank_in_initial_credit_level: 801u32,
+            number_of_referees: 2,
+            current_credit_level: CreditLevel::Two,
+            reward_eras: 270,
+        };
         assert_ok!(DeeperNode::im_online(Origin::signed(12)));
+        UserCredit::<Test>::insert(12, credit_data.clone());
+        Credit::init_delegator_history(&12, 0);
         //reward_countdown
         // era 1
         run_to_block(BLOCKS_PER_ERA);
-        assert_eq!(Credit::user_credit_history(12), vec![]);
+        assert_eq!(Credit::user_credit_history(12)[0].0, 0);
         Credit::get_reward(&12, 0, 0);
         let remain_eras = Credit::reward_countdown(12).unwrap_or(0);
         assert_eq!(remain_eras, 269);
 
-        let credit_historys = vec![(
-            0,
-            CreditData {
-                campaign_id: 1,
-                credit: 200,
-                initial_credit_level: CreditLevel::Two,
-                rank_in_initial_credit_level: 801u32,
-                number_of_referees: 2,
-                current_credit_level: CreditLevel::Two,
-                reward_eras: 270,
-            },
-        )];
+        let credit_historys = vec![(0, credit_data)];
         assert_eq!(Credit::user_credit_history(12), credit_historys);
 
         // era 10

--- a/pallets/credit/src/tests.rs
+++ b/pallets/credit/src/tests.rs
@@ -168,7 +168,7 @@ fn add_or_update_credit_data_check_credit_history_and_reward() {
         // era 1
         run_to_block(BLOCKS_PER_ERA);
         assert_eq!(Credit::user_credit_history(3), vec![]);
-        Credit::init_delegator_history(&3, 0);
+        assert!(Credit::init_delegator_history(&3, 0));
         assert_eq!(
             Credit::get_reward(&3, 0, 0).0,
             Some((0, 21369858941948251800))
@@ -348,12 +348,12 @@ fn update_credit_by_traffic() {
 fn get_reward_work() {
     new_test_ext().execute_with(|| {
         assert_eq!(Credit::get_reward(&3, 0, 0).0, None);
-        Credit::init_delegator_history(&3, 0);
-        Credit::init_delegator_history(&7, 0);
-        Credit::init_delegator_history(&8, 0);
-        Credit::init_delegator_history(&9, 0);
-        Credit::init_delegator_history(&10, 0);
-        Credit::init_delegator_history(&11, 0);
+        assert!(Credit::init_delegator_history(&3, 0));
+        assert!(Credit::init_delegator_history(&7, 0));
+        assert!(Credit::init_delegator_history(&8, 0));
+        assert!(Credit::init_delegator_history(&9, 0));
+        assert!(Credit::init_delegator_history(&10, 0));
+        assert!(Credit::init_delegator_history(&11, 0));
         run_to_block(BLOCKS_PER_ERA); // era 1
         assert_eq!(
             Credit::get_reward(&3, 0, 0).0,
@@ -410,7 +410,7 @@ fn get_reward_with_update_credit_no_bonus() {
         Timestamp::set_timestamp(INIT_TIMESTAMP);
         assert_ok!(DeeperNode::im_online(Origin::signed(6)));
         assert_eq!(Credit::user_credit(&6).unwrap().credit, 100);
-        Credit::init_delegator_history(&6, 0);
+        assert!(Credit::init_delegator_history(&6, 0));
         run_to_block(BLOCKS_PER_ERA);
         assert_eq!(
             Credit::get_reward(&6, 0, 0).0,
@@ -451,7 +451,7 @@ fn get_reward_with_update_credit_with_bonus() {
     new_test_ext().execute_with(|| {
         assert_ok!(DeeperNode::im_online(Origin::signed(7)));
         assert_eq!(Credit::user_credit(&7).unwrap().credit, 400);
-        Credit::init_delegator_history(&7, 0);
+        assert!(Credit::init_delegator_history(&7, 0));
         run_to_block(BLOCKS_PER_ERA);
         assert_eq!(
             Credit::get_reward(&7, 0, 0).0,
@@ -491,7 +491,7 @@ fn get_reward_with_update_credit_with_bonus() {
 fn get_reward_with_slash_credit_with_bonus() {
     new_test_ext().execute_with(|| {
         assert_eq!(Credit::user_credit(&7).unwrap().credit, 400);
-        Credit::init_delegator_history(&7, 0);
+        assert!(Credit::init_delegator_history(&7, 0));
         run_to_block(BLOCKS_PER_ERA);
         assert_eq!(
             Credit::get_reward(&7, 0, 0).0,
@@ -567,7 +567,7 @@ fn update_credit_history_when_era_is_the_same() {
                 reward_eras: 270,
             },
         );
-        Credit::init_delegator_history(&1, 0);
+        assert!(Credit::init_delegator_history(&1, 0));
         //default era=0
 
         let credit_historys = vec![(
@@ -605,7 +605,7 @@ fn update_credit_history_when_era_is_non_zero() {
         );
         // run_to_block, era=1
         run_to_block(BLOCKS_PER_ERA);
-        Credit::init_delegator_history(&1, 1);
+        assert!(Credit::init_delegator_history(&1, 1));
         Credit::update_credit_history(&1, 10);
 
         let credit_historys = vec![
@@ -654,7 +654,7 @@ fn reward_remain_eras_count() {
         };
         assert_ok!(DeeperNode::im_online(Origin::signed(12)));
         UserCredit::<Test>::insert(12, credit_data.clone());
-        Credit::init_delegator_history(&12, 0);
+        assert!(Credit::init_delegator_history(&12, 0));
         //reward_countdown
         // era 1
         run_to_block(BLOCKS_PER_ERA);


### PR DESCRIPTION
1. staking function delegate use same era calculation  as credit pallet
2. account credit history in credit pallet,  only be initialized by staking pallet's function 'fn delegate'
3. pay reward for delegator  no matter if the delegaor is ever online ,just consider if it has enough credit