### PR TITLE
credit and micropayment depends on treasury directly

### DIFF
--- a/pallets/credit/Cargo.toml
+++ b/pallets/credit/Cargo.toml
@@ -25,13 +25,13 @@ pallet-balances = { version = "3.0.0", default-features = false, git = "https://
 pallet-deeper-node = { version = "3.0.0", default-features = false, path = "../deeper-node" }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 pallet-timestamp = {default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
+pallet-treasury = {default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
 
 # Optional imports for benchmarking
 frame-benchmarking = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12", optional = true }
 
 [dev-dependencies]
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
-pallet-treasury = {default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
 
 [features]
 default = ['std']

--- a/pallets/micropayment/Cargo.toml
+++ b/pallets/micropayment/Cargo.toml
@@ -28,6 +28,8 @@ sp-core = {default-features = false, git = "https://github.com/paritytech/substr
 sp-io = {default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
 sp-runtime = {default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
 sp-std = {default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
+pallet-treasury = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12", default-features = false }
+
 # Optional imports for benchmarking
 frame-benchmarking = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12", optional = true }
 hex-literal = "0.3.1"
@@ -35,7 +37,6 @@ hex-literal = "0.3.1"
 [dev-dependencies]
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12" }
 serde = { version = "1.0.101" }
-pallet-treasury = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.12", default-features = false }
 
 [features]
 default = ['std']


### PR DESCRIPTION
runtime depends on pallet-credit, pallet-credit depends on pallet-treasury, so the decency should be defined explicitly not in `dev-dependencies`