### PR TITLE
add benchmarking for force_modify_credit_history

### DIFF
--- a/pallets/credit/src/benchmarking.rs
+++ b/pallets/credit/src/benchmarking.rs
@@ -90,6 +90,24 @@ benchmarks! {
     verify {
         assert_eq!(UserCredit::<T>::get(&user).unwrap().credit,101);
     }
+
+    force_modify_credit_history {
+        let credit_data = CreditData {
+            campaign_id: 0,
+            credit: 100,
+            initial_credit_level: CreditLevel::One,
+            rank_in_initial_credit_level: 0,
+            number_of_referees: 1,
+            current_credit_level: CreditLevel::One,
+            reward_eras: 270,
+        };
+        let user = create_funded_user::<T>("user",USER_SEED, 1000);
+        UserCredit::<T>::insert(&user,credit_data.clone());
+        UserCreditHistory::<T>::insert(&user,vec![(6,credit_data.clone())]);
+    }: _(RawOrigin::Root, user.clone(), 7)
+    verify {
+        assert_eq!(UserCreditHistory::<T>::get(&user), vec![(7, credit_data)]);
+    }
 }
 
 #[cfg(test)]

--- a/pallets/credit/src/weights.rs
+++ b/pallets/credit/src/weights.rs
@@ -69,9 +69,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
             .saturating_add(T::DbWeight::get().writes(3 as Weight))
     }
     fn force_modify_credit_history() -> Weight {
-        (76_885_000 as Weight)
-            .saturating_add(T::DbWeight::get().reads(3 as Weight))
-            .saturating_add(T::DbWeight::get().writes(3 as Weight))
+        (17_599_000 as Weight)
+            .saturating_add(T::DbWeight::get().reads(1 as Weight))
+            .saturating_add(T::DbWeight::get().writes(1 as Weight))
     }
 }
 
@@ -91,8 +91,8 @@ impl WeightInfo for () {
             .saturating_add(RocksDbWeight::get().writes(3 as Weight))
     }
     fn force_modify_credit_history() -> Weight {
-        (76_885_000 as Weight)
-            .saturating_add(RocksDbWeight::get().reads(3 as Weight))
-            .saturating_add(RocksDbWeight::get().writes(3 as Weight))
+        (17_599_000 as Weight)
+            .saturating_add(RocksDbWeight::get().reads(1 as Weight))
+            .saturating_add(RocksDbWeight::get().writes(1 as Weight))
     }
 }


### PR DESCRIPTION
In the previous pull request(https://github.com/deeper-chain/deeper-chain/pull/197) I forgot to write benchmarking, in this pull request benchmarking is added and weight is updated.