### PR TITLE
remove duplicated credit events

### DIFF
--- a/pallets/credit/src/lib.rs
+++ b/pallets/credit/src/lib.rs
@@ -392,16 +392,16 @@ pub mod pallet {
             ensure_root(origin)?;
             Self::check_credit_data(&credit_data)?;
 
-            let current_era = Self::get_current_era();
             if UserCredit::<T>::contains_key(&account_id) {
                 UserCredit::<T>::mutate(&account_id, |d| match d {
                     Some(data) => *data = credit_data.clone(),
                     _ => (),
                 });
-                Self::update_credit_history(&account_id, current_era);
+                if !Self::user_credit_history(&account_id).is_empty() {
+                    Self::update_credit_history(&account_id, Self::get_current_era());
+                }
             } else {
                 UserCredit::<T>::insert(&account_id, credit_data.clone());
-                Self::init_credit_history(&account_id, credit_data.clone(), current_era);
             }
             Self::deposit_event(Event::CreditUpdateSuccess(account_id, credit_data.credit));
             Ok(().into())

--- a/pallets/credit/src/tests.rs
+++ b/pallets/credit/src/tests.rs
@@ -142,10 +142,7 @@ fn add_or_update_credit_data() {
             credit_data.clone()
         ));
         assert_eq!(Credit::user_credit(14), Some(credit_data.clone()));
-        assert_eq!(
-            Credit::user_credit_history(14),
-            vec![(1, credit_data.clone())]
-        );
+        assert_eq!(Credit::user_credit_history(14), vec![]);
         assert_eq!(
             <frame_system::Pallet<Test>>::events()
                 .pop()

--- a/pallets/credit/src/tests.rs
+++ b/pallets/credit/src/tests.rs
@@ -119,12 +119,40 @@ fn add_or_update_credit_data() {
         );
 
         // update_credit_data works
+        run_to_block(1);
         assert_ok!(Credit::add_or_update_credit_data(
             RawOrigin::Root.into(),
             1,
             credit_data.clone()
         ));
-        assert_eq!(Credit::user_credit(1), Some(credit_data));
+        assert_eq!(Credit::user_credit(1), Some(credit_data.clone()));
+        assert_eq!(
+            <frame_system::Pallet<Test>>::events()
+                .pop()
+                .expect("should contains events")
+                .event,
+            crate::tests::Event::from(crate::Event::CreditUpdateSuccess(1, 100))
+        );
+
+        // add_credit_data works
+        run_to_block(2 * BLOCKS_PER_ERA - 1);
+        assert_ok!(Credit::add_or_update_credit_data(
+            RawOrigin::Root.into(),
+            14,
+            credit_data.clone()
+        ));
+        assert_eq!(Credit::user_credit(14), Some(credit_data.clone()));
+        assert_eq!(
+            Credit::user_credit_history(14),
+            vec![(1, credit_data.clone())]
+        );
+        assert_eq!(
+            <frame_system::Pallet<Test>>::events()
+                .pop()
+                .expect("should contains events")
+                .event,
+            crate::tests::Event::from(crate::Event::CreditUpdateSuccess(14, 100))
+        );
 
         // credit_data invalid
         let credit_data = CreditData {


### PR DESCRIPTION
1. `CreditDataAdded`, `CreditDataUpdated` were replaced by `CreditUpdateSuccess`
2. `update_credit_history` when executing `update_credit_data`
3. insert credit_history when executing `add_credit_data`