### PR TITLE
quick update spec_version:16

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -156,7 +156,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // and set impl_version to 0. If only runtime
     // implementation changes and behavior does not, then leave spec_version as
     // is and increment impl_version.
-    spec_version: 15,
+    spec_version: 16,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 9,


### PR DESCRIPTION
This update is a quick update to work with the unstake feature in order to address user staking credit score uploads. When a user unstake, their staking credit score will be accurately deducted, but the behavior accumulated credit score will not be deducted

links：[add credt admin's function](https://github.com/deeper-chain/deeper-chain/commit/82e9eda35b2e837794a6cf30b305e6f8ba3ccfcc)