### PR TITLE
add slash_staking_credit_update_credit_history

### DIFF
--- a/pallets/credit/src/lib.rs
+++ b/pallets/credit/src/lib.rs
@@ -1500,6 +1500,7 @@ pub mod pallet {
             let credit_data = CreditData::new(camp_id, new_score);
             UserCredit::<T>::insert(user, credit_data);
             UserStakingCredit::<T>::remove(user);
+            Self::update_credit_history(&user, Self::get_current_era());
 
             Ok(())
         }


### PR DESCRIPTION
get_credit_map calculates PoCr earnings based on credit score history changes, and must update credit score history when unstake deducts staking credit score