### PR TITLE
add feature for testnet's chainid diff with mainnet

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -239,3 +239,5 @@ runtime-benchmarks = [
 	"pallet-ethereum/runtime-benchmarks",
 	"pallet-evm/runtime-benchmarks",
 ]
+
+testnet = []

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1282,8 +1282,16 @@ impl GasWeightMapping for FixedGasWeightMapping {
     }
 }
 
+#[cfg(feature = "testnet")]
 parameter_types! {
-    pub const ChainId: u64 = 518;
+pub const ChainId: u64 = 518518;
+}
+#[cfg(not(feature = "testnet"))]
+parameter_types! {
+pub const ChainId: u64 = 518;
+}
+
+parameter_types! {
     pub BlockGasLimit: U256 = U256::from(NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT / WEIGHT_PER_GAS);
     pub PrecompilesValue: FrontierPrecompiles<Runtime> = FrontierPrecompiles::<_>::new();
 }


### PR DESCRIPTION
add feature for testnet's chainid diff with mainnet
if compile for testnet version: 
cargo build --features testnet