### PR TITLE
update frontier to latest commit of frontier_sync branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1615,7 +1615,7 @@ dependencies = [
 [[package]]
 name = "fc-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/deeper-chain/frontier.git?branch=frontier_sync#783798ebcc4582c842e735990f1c57d3f4f8734d"
+source = "git+https://github.com/deeper-chain/frontier.git?branch=frontier_sync#afe98e6e7adf1749f2e116f0dc6e9ee9f83f5ae3"
 dependencies = [
  "async-trait",
  "fc-db",
@@ -1634,7 +1634,7 @@ dependencies = [
 [[package]]
 name = "fc-db"
 version = "2.0.0-dev"
-source = "git+https://github.com/deeper-chain/frontier.git?branch=frontier_sync#783798ebcc4582c842e735990f1c57d3f4f8734d"
+source = "git+https://github.com/deeper-chain/frontier.git?branch=frontier_sync#afe98e6e7adf1749f2e116f0dc6e9ee9f83f5ae3"
 dependencies = [
  "fp-storage",
  "kvdb-rocksdb",
@@ -1650,7 +1650,7 @@ dependencies = [
 [[package]]
 name = "fc-mapping-sync"
 version = "2.0.0-dev"
-source = "git+https://github.com/deeper-chain/frontier.git?branch=frontier_sync#783798ebcc4582c842e735990f1c57d3f4f8734d"
+source = "git+https://github.com/deeper-chain/frontier.git?branch=frontier_sync#afe98e6e7adf1749f2e116f0dc6e9ee9f83f5ae3"
 dependencies = [
  "fc-db",
  "fp-consensus",
@@ -1667,7 +1667,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/deeper-chain/frontier.git?branch=frontier_sync#783798ebcc4582c842e735990f1c57d3f4f8734d"
+source = "git+https://github.com/deeper-chain/frontier.git?branch=frontier_sync#afe98e6e7adf1749f2e116f0dc6e9ee9f83f5ae3"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -1710,7 +1710,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-core"
 version = "1.1.0-dev"
-source = "git+https://github.com/deeper-chain/frontier.git?branch=frontier_sync#783798ebcc4582c842e735990f1c57d3f4f8734d"
+source = "git+https://github.com/deeper-chain/frontier.git?branch=frontier_sync#afe98e6e7adf1749f2e116f0dc6e9ee9f83f5ae3"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "fp-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/deeper-chain/frontier.git?branch=frontier_sync#783798ebcc4582c842e735990f1c57d3f4f8734d"
+source = "git+https://github.com/deeper-chain/frontier.git?branch=frontier_sync#afe98e6e7adf1749f2e116f0dc6e9ee9f83f5ae3"
 dependencies = [
  "ethereum",
  "parity-scale-codec",
@@ -1830,7 +1830,7 @@ dependencies = [
 [[package]]
 name = "fp-dynamic-fee"
 version = "1.0.0"
-source = "git+https://github.com/deeper-chain/frontier.git?branch=frontier_sync#783798ebcc4582c842e735990f1c57d3f4f8734d"
+source = "git+https://github.com/deeper-chain/frontier.git?branch=frontier_sync#afe98e6e7adf1749f2e116f0dc6e9ee9f83f5ae3"
 dependencies = [
  "async-trait",
  "sp-core",
@@ -1840,7 +1840,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "3.0.0-dev"
-source = "git+https://github.com/deeper-chain/frontier.git?branch=frontier_sync#783798ebcc4582c842e735990f1c57d3f4f8734d"
+source = "git+https://github.com/deeper-chain/frontier.git?branch=frontier_sync#afe98e6e7adf1749f2e116f0dc6e9ee9f83f5ae3"
 dependencies = [
  "evm",
  "frame-support",
@@ -1853,7 +1853,7 @@ dependencies = [
 [[package]]
 name = "fp-rpc"
 version = "3.0.0-dev"
-source = "git+https://github.com/deeper-chain/frontier.git?branch=frontier_sync#783798ebcc4582c842e735990f1c57d3f4f8734d"
+source = "git+https://github.com/deeper-chain/frontier.git?branch=frontier_sync#afe98e6e7adf1749f2e116f0dc6e9ee9f83f5ae3"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -1871,7 +1871,7 @@ dependencies = [
 [[package]]
 name = "fp-self-contained"
 version = "1.0.0-dev"
-source = "git+https://github.com/deeper-chain/frontier.git?branch=frontier_sync#783798ebcc4582c842e735990f1c57d3f4f8734d"
+source = "git+https://github.com/deeper-chain/frontier.git?branch=frontier_sync#afe98e6e7adf1749f2e116f0dc6e9ee9f83f5ae3"
 dependencies = [
  "ethereum",
  "frame-support",
@@ -1887,7 +1887,7 @@ dependencies = [
 [[package]]
 name = "fp-storage"
 version = "2.0.0"
-source = "git+https://github.com/deeper-chain/frontier.git?branch=frontier_sync#783798ebcc4582c842e735990f1c57d3f4f8734d"
+source = "git+https://github.com/deeper-chain/frontier.git?branch=frontier_sync#afe98e6e7adf1749f2e116f0dc6e9ee9f83f5ae3"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -4866,7 +4866,7 @@ dependencies = [
 [[package]]
 name = "pallet-base-fee"
 version = "1.0.0"
-source = "git+https://github.com/deeper-chain/frontier.git?branch=frontier_sync#783798ebcc4582c842e735990f1c57d3f4f8734d"
+source = "git+https://github.com/deeper-chain/frontier.git?branch=frontier_sync#afe98e6e7adf1749f2e116f0dc6e9ee9f83f5ae3"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -5103,7 +5103,7 @@ dependencies = [
 [[package]]
 name = "pallet-dynamic-fee"
 version = "4.0.0-dev"
-source = "git+https://github.com/deeper-chain/frontier.git?branch=frontier_sync#783798ebcc4582c842e735990f1c57d3f4f8734d"
+source = "git+https://github.com/deeper-chain/frontier.git?branch=frontier_sync#afe98e6e7adf1749f2e116f0dc6e9ee9f83f5ae3"
 dependencies = [
  "async-trait",
  "fp-dynamic-fee",
@@ -5140,7 +5140,7 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "4.0.0-dev"
-source = "git+https://github.com/deeper-chain/frontier.git?branch=frontier_sync#783798ebcc4582c842e735990f1c57d3f4f8734d"
+source = "git+https://github.com/deeper-chain/frontier.git?branch=frontier_sync#afe98e6e7adf1749f2e116f0dc6e9ee9f83f5ae3"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -5167,7 +5167,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "6.0.0-dev"
-source = "git+https://github.com/deeper-chain/frontier.git?branch=frontier_sync#783798ebcc4582c842e735990f1c57d3f4f8734d"
+source = "git+https://github.com/deeper-chain/frontier.git?branch=frontier_sync#afe98e6e7adf1749f2e116f0dc6e9ee9f83f5ae3"
 dependencies = [
  "evm",
  "fp-evm",
@@ -5193,7 +5193,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-blake2"
 version = "2.0.0-dev"
-source = "git+https://github.com/deeper-chain/frontier.git?branch=frontier_sync#783798ebcc4582c842e735990f1c57d3f4f8734d"
+source = "git+https://github.com/deeper-chain/frontier.git?branch=frontier_sync#afe98e6e7adf1749f2e116f0dc6e9ee9f83f5ae3"
 dependencies = [
  "fp-evm",
 ]
@@ -5201,7 +5201,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-bn128"
 version = "2.0.0-dev"
-source = "git+https://github.com/deeper-chain/frontier.git?branch=frontier_sync#783798ebcc4582c842e735990f1c57d3f4f8734d"
+source = "git+https://github.com/deeper-chain/frontier.git?branch=frontier_sync#afe98e6e7adf1749f2e116f0dc6e9ee9f83f5ae3"
 dependencies = [
  "fp-evm",
  "sp-core",
@@ -5211,7 +5211,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-curve25519"
 version = "1.0.0-dev"
-source = "git+https://github.com/deeper-chain/frontier.git?branch=frontier_sync#783798ebcc4582c842e735990f1c57d3f4f8734d"
+source = "git+https://github.com/deeper-chain/frontier.git?branch=frontier_sync#afe98e6e7adf1749f2e116f0dc6e9ee9f83f5ae3"
 dependencies = [
  "curve25519-dalek 4.0.0-pre.1",
  "fp-evm",
@@ -5220,7 +5220,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-dispatch"
 version = "2.0.0-dev"
-source = "git+https://github.com/deeper-chain/frontier.git?branch=frontier_sync#783798ebcc4582c842e735990f1c57d3f4f8734d"
+source = "git+https://github.com/deeper-chain/frontier.git?branch=frontier_sync#afe98e6e7adf1749f2e116f0dc6e9ee9f83f5ae3"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -5230,7 +5230,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-ed25519"
 version = "2.0.0-dev"
-source = "git+https://github.com/deeper-chain/frontier.git?branch=frontier_sync#783798ebcc4582c842e735990f1c57d3f4f8734d"
+source = "git+https://github.com/deeper-chain/frontier.git?branch=frontier_sync#afe98e6e7adf1749f2e116f0dc6e9ee9f83f5ae3"
 dependencies = [
  "ed25519-dalek",
  "fp-evm",
@@ -5239,7 +5239,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0-dev"
-source = "git+https://github.com/deeper-chain/frontier.git?branch=frontier_sync#783798ebcc4582c842e735990f1c57d3f4f8734d"
+source = "git+https://github.com/deeper-chain/frontier.git?branch=frontier_sync#afe98e6e7adf1749f2e116f0dc6e9ee9f83f5ae3"
 dependencies = [
  "fp-evm",
  "num",
@@ -5248,7 +5248,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-sha3fips"
 version = "2.0.0-dev"
-source = "git+https://github.com/deeper-chain/frontier.git?branch=frontier_sync#783798ebcc4582c842e735990f1c57d3f4f8734d"
+source = "git+https://github.com/deeper-chain/frontier.git?branch=frontier_sync#afe98e6e7adf1749f2e116f0dc6e9ee9f83f5ae3"
 dependencies = [
  "fp-evm",
  "tiny-keccak",
@@ -5257,7 +5257,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-simple"
 version = "2.0.0-dev"
-source = "git+https://github.com/deeper-chain/frontier.git?branch=frontier_sync#783798ebcc4582c842e735990f1c57d3f4f8734d"
+source = "git+https://github.com/deeper-chain/frontier.git?branch=frontier_sync#afe98e6e7adf1749f2e116f0dc6e9ee9f83f5ae3"
 dependencies = [
  "fp-evm",
  "ripemd",


### PR DESCRIPTION
apply `cargo update -p pallet-evm` to update to latest commit. The old version doesn't contains `rewards_accounts_evm_deeper`