### PR TITLE
npow use the new permission system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5494,6 +5494,7 @@ dependencies = [
  "pallet-credit",
  "pallet-evm",
  "pallet-timestamp",
+ "pallet-user-privileges",
  "parity-scale-codec",
  "scale-info",
  "serde",

--- a/pallets/operation/Cargo.toml
+++ b/pallets/operation/Cargo.toml
@@ -24,6 +24,7 @@ log = { version = "0.4.14", default-features = false }
 sp-core = {default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19" }
 pallet-credit = { default-features = false, path = "../credit", version = "3.0.0" }
 pallet-evm = { default-features = false, git = "https://github.com/deeper-chain/frontier.git", branch = "feature/add-npow" }
+pallet-user-privileges = { default-features = false, path = "../user-privileges" }
 
 # Optional imports for benchmarking
 frame-benchmarking = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19", optional = true }

--- a/pallets/staking/src/mock.rs
+++ b/pallets/staking/src/mock.rs
@@ -289,6 +289,7 @@ impl pallet_operation::Config for Test {
     type MinimumBurnedDPR = MinimumBurnedDPR;
     type CreditInterface = Credit;
     type NpowAddressMapping = ();
+    type UserPrivilegeInterface = ();
 }
 
 parameter_types! {

--- a/pallets/user-privileges/src/lib.rs
+++ b/pallets/user-privileges/src/lib.rs
@@ -90,7 +90,7 @@ pub mod pallet {
         fn type_info() -> Type {
             Type::builder()
                 .path(Path::new("BitFlags", module_path!()))
-                .type_params(sp_std::vec![TypeParameter::new(
+                .type_params(vec![TypeParameter::new(
                     "T",
                     Some(meta_type::<Privilege>()),
                 )])
@@ -302,7 +302,7 @@ pub mod pallet {
 
     impl<T: Config> UserPrivilegeInterface<T::AccountId> for Pallet<T> {
         fn has_privilege(user: &T::AccountId, p: Privilege) -> bool {
-            let privs = UserPrivileges::<T>::get(user);
+            let privs = Self::user_privileges(user);
             match privs {
                 None => false,
                 Some(privs) => privs.0.contains(p),
@@ -310,7 +310,7 @@ pub mod pallet {
         }
 
         fn has_evm_privilege(user: &H160, p: Privilege) -> bool {
-            let privs = EvmAddressPrivileges::<T>::get(user);
+            let privs = Self::evm_address_privileges(user);
             match privs {
                 None => false,
                 Some(privs) => privs.0.contains(p),

--- a/pallets/user-privileges/src/lib.rs
+++ b/pallets/user-privileges/src/lib.rs
@@ -54,6 +54,7 @@ pub mod pallet {
         ReleaseSetter = 1 << 1,
         EvmAddressSetter = 1 << 2,
         EvmCreditOperation = 1 << 3,
+        NpowMint = 1 << 4,
     }
 
     /// Wrapper type for `BitFlags<Privilege>` that implements `Codec`.
@@ -89,7 +90,7 @@ pub mod pallet {
         fn type_info() -> Type {
             Type::builder()
                 .path(Path::new("BitFlags", module_path!()))
-                .type_params(vec![TypeParameter::new(
+                .type_params(sp_std::vec![TypeParameter::new(
                     "T",
                     Some(meta_type::<Privilege>()),
                 )])

--- a/pallets/user-privileges/src/lib.rs
+++ b/pallets/user-privileges/src/lib.rs
@@ -108,7 +108,6 @@ pub mod pallet {
         type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
         type ForceOrigin: EnsureOrigin<Self::Origin>;
         type WeightInfo: WeightInfo;
-        type UserPrivilegeInterface: UserPrivilegeInterface<Self::AccountId>;
     }
 
     #[pallet::pallet]
@@ -250,7 +249,7 @@ pub mod pallet {
         ) -> DispatchResult {
             let sender = ensure_signed(origin)?;
             ensure!(
-                T::UserPrivilegeInterface::has_privilege(&sender, Privilege::EvmAddressSetter),
+                Self::has_privilege(&sender, Privilege::EvmAddressSetter),
                 Error::<T>::NoPermission
             );
             let old_priv = Self::evm_address_privileges(&who);
@@ -273,7 +272,7 @@ pub mod pallet {
         ) -> DispatchResult {
             let sender = ensure_signed(origin)?;
             ensure!(
-                T::UserPrivilegeInterface::has_privilege(&sender, Privilege::EvmAddressSetter),
+                Self::has_privilege(&sender, Privilege::EvmAddressSetter),
                 Error::<T>::NoPermission
             );
             let old_priv = Self::evm_address_privileges(&who);
@@ -292,7 +291,7 @@ pub mod pallet {
         pub fn clear_evm_privilege(origin: OriginFor<T>, who: H160) -> DispatchResult {
             let sender = ensure_signed(origin)?;
             ensure!(
-                T::UserPrivilegeInterface::has_privilege(&sender, Privilege::EvmAddressSetter),
+                Self::has_privilege(&sender, Privilege::EvmAddressSetter),
                 Error::<T>::NoPermission
             );
             EvmAddressPrivileges::<T>::remove(&who);
@@ -301,9 +300,7 @@ pub mod pallet {
         }
     }
 
-    pub struct DefaultPrivilegeHandler<T>(sp_std::marker::PhantomData<T>);
-
-    impl<T: Config> UserPrivilegeInterface<T::AccountId> for DefaultPrivilegeHandler<T> {
+    impl<T: Config> UserPrivilegeInterface<T::AccountId> for Pallet<T> {
         fn has_privilege(user: &T::AccountId, p: Privilege) -> bool {
             let privs = UserPrivileges::<T>::get(user);
             match privs {
@@ -321,13 +318,13 @@ pub mod pallet {
         }
     }
 
-    impl<T: Config> UserPrivilegeInterface<T::AccountId> for Pallet<T> {
-        fn has_privilege(user: &T::AccountId, p: Privilege) -> bool {
-            T::UserPrivilegeInterface::has_privilege(user, p)
+    impl<Account> UserPrivilegeInterface<Account> for () {
+        fn has_privilege(_user: &Account, _p: Privilege) -> bool {
+            true
         }
 
-        fn has_evm_privilege(user: &H160, p: Privilege) -> bool {
-            T::UserPrivilegeInterface::has_evm_privilege(user, p)
+        fn has_evm_privilege(_user: &H160, _p: Privilege) -> bool {
+            true
         }
     }
 }

--- a/pallets/user-privileges/src/tests.rs
+++ b/pallets/user-privileges/src/tests.rs
@@ -82,6 +82,7 @@ impl pallet_user_privileges::Config for Test {
     type Event = Event;
     type ForceOrigin = EnsureRoot<Self::AccountId>;
     type WeightInfo = ();
+    type UserPrivilegeInterface = DefaultPrivilegeHandler<Self>;
 }
 
 pub fn new_test_ext() -> sp_io::TestExternalities {

--- a/pallets/user-privileges/src/tests.rs
+++ b/pallets/user-privileges/src/tests.rs
@@ -82,7 +82,6 @@ impl pallet_user_privileges::Config for Test {
     type Event = Event;
     type ForceOrigin = EnsureRoot<Self::AccountId>;
     type WeightInfo = ();
-    type UserPrivilegeInterface = DefaultPrivilegeHandler<Self>;
 }
 
 pub fn new_test_ext() -> sp_io::TestExternalities {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -80,6 +80,7 @@ use pallet_evm::{
     Account as EVMAccount, EVMCurrencyAdapter, GasWeightMapping, PairedAddressMapping,
     PairedNpowAddressMapping, Runner,
 };
+use pallet_user_privileges::DefaultPrivilegeHandler;
 
 mod precompiles;
 use precompiles::FrontierPrecompiles;
@@ -489,6 +490,7 @@ impl pallet_operation::Config for Runtime {
     type MinimumBurnedDPR = MinimumBurnedDPR;
     type CreditInterface = Credit;
     type NpowAddressMapping = PairedNpowAddressMapping<Runtime>;
+    type UserPrivilegeInterface = DefaultPrivilegeHandler<Runtime>;
 }
 
 parameter_types! {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -477,6 +477,7 @@ impl pallet_user_privileges::Config for Runtime {
     type Event = Event;
     type ForceOrigin = frame_system::EnsureRoot<AccountId>;
     type WeightInfo = pallet_user_privileges::weights::SubstrateWeight<Runtime>;
+    type UserPrivilegeInterface = pallet_user_privileges::DefaultPrivilegeHandler<Runtime>;
 }
 
 impl pallet_operation::Config for Runtime {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -80,7 +80,6 @@ use pallet_evm::{
     Account as EVMAccount, EVMCurrencyAdapter, GasWeightMapping, PairedAddressMapping,
     PairedNpowAddressMapping, Runner,
 };
-use pallet_user_privileges::DefaultPrivilegeHandler;
 
 mod precompiles;
 use precompiles::FrontierPrecompiles;
@@ -478,7 +477,6 @@ impl pallet_user_privileges::Config for Runtime {
     type Event = Event;
     type ForceOrigin = frame_system::EnsureRoot<AccountId>;
     type WeightInfo = pallet_user_privileges::weights::SubstrateWeight<Runtime>;
-    type UserPrivilegeInterface = pallet_user_privileges::DefaultPrivilegeHandler<Runtime>;
 }
 
 impl pallet_operation::Config for Runtime {
@@ -490,7 +488,7 @@ impl pallet_operation::Config for Runtime {
     type MinimumBurnedDPR = MinimumBurnedDPR;
     type CreditInterface = Credit;
     type NpowAddressMapping = PairedNpowAddressMapping<Runtime>;
-    type UserPrivilegeInterface = DefaultPrivilegeHandler<Runtime>;
+    type UserPrivilegeInterface = UserPrivileges;
 }
 
 parameter_types! {


### PR DESCRIPTION
1. `Privilege` doesn't need to be generic parameter
2. Make `UserPrivilegeInterface` a trait placeholder so we can customize it in runtime or in unit tests.