### PR TITLE
quick update spec_version:23

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -152,7 +152,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // and set impl_version to 0. If only runtime
     // implementation changes and behavior does not, then leave spec_version as
     // is and increment impl_version.
-    spec_version: 22,
+    spec_version: 23,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 10,


### PR DESCRIPTION
[add right check for evm operating deeper's credit](https://github.com/deeper-chain/deeper-chain/commit/7688432f0167675ea5c5d9e261eb15972d7a2546)