### PR TITLE
remove NpowAddressMapping trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5515,7 +5515,6 @@ dependencies = [
  "log",
  "node-primitives",
  "pallet-balances",
- "pallet-evm",
  "pallet-timestamp",
  "pallet-user-privileges",
  "parity-scale-codec",

--- a/pallets/deeper-node/src/benchmarking.rs
+++ b/pallets/deeper-node/src/benchmarking.rs
@@ -138,6 +138,16 @@ benchmarks! {
     verify {
         assert_eq!(RewardsAccountsDeepertoEVM::<T>::get(&admin), Some(evm_address));
     }
+
+    get_npow_reward {
+        let existential_deposit = <T as pallet::Config>::Currency::minimum_balance();
+        let user: T::AccountId = account("user", 0, SEED);
+        let _ = <T as pallet::Config>::Currency::make_free_balance_be(&user, existential_deposit*2u32.into());
+
+        let _ = EvmPallet::<T>::reward_mapping(RawOrigin::Signed(user.clone()).into(),H160::zero());
+    }: _(RawOrigin::Signed(user))
+    verify {
+    }
 }
 
 #[cfg(test)]

--- a/pallets/deeper-node/src/lib.rs
+++ b/pallets/deeper-node/src/lib.rs
@@ -201,6 +201,9 @@ pub mod pallet {
         RewardsAccounts(T::AccountId, H160),
         /// Switch Bind worker eth_address to reward address
         RewardsAccountsSwitch(T::AccountId, H160, H160),
+
+        /// send this event to let system mint dpr to user
+        GetNpowReward(T::AccountId, H160),
     }
 
     // Errors inform users that something went wrong.
@@ -228,6 +231,8 @@ pub mod pallet {
         EthAddressAlreadyMapped,
         /// No binding information
         NotBound,
+        /// no coresponding evm address
+        NpowRewardAddressNotFound,
     }
 
     #[pallet::hooks]
@@ -431,6 +436,18 @@ pub mod pallet {
                 Self::deposit_event(Event::RewardsAccounts(deeper_address, eth_address));
             }
             Ok(().into())
+        }
+
+        #[pallet::weight(T::WeightInfo::get_npow_reward())]
+        pub fn get_npow_reward(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
+            let sender = ensure_signed(origin)?;
+            match Self::rewards_accounts_deeper_evm(&sender) {
+                Some(evm_address) => {
+                    Self::deposit_event(Event::<T>::GetNpowReward(sender, evm_address));
+                    Ok(().into())
+                }
+                None => Err(Error::<T>::NpowRewardAddressNotFound)?,
+            }
         }
     }
 

--- a/pallets/deeper-node/src/tests.rs
+++ b/pallets/deeper-node/src/tests.rs
@@ -323,3 +323,29 @@ fn get_eras_offline() {
         assert_eq!(DeeperNode::get_eras_offline(&2), 3);
     });
 }
+
+#[test]
+fn get_npow_reward() {
+    new_test_ext().execute_with(|| {
+        run_to_block(1);
+        assert_err!(
+            DeeperNode::get_npow_reward(Origin::signed(2)),
+            Error::<Test>::NpowRewardAddressNotFound
+        );
+
+        assert_ok!(DeeperNode::reward_mapping(
+            Origin::signed(1),
+            0,
+            Vec::new(),
+            H160::zero(),
+        ));
+        assert_ok!(DeeperNode::get_npow_reward(Origin::signed(1)));
+        assert_eq!(
+            <frame_system::Pallet<Test>>::events()
+                .pop()
+                .expect("should contains events")
+                .event,
+            crate::tests::Event::from(crate::Event::GetNpowReward(1, H160::zero()))
+        );
+    });
+}

--- a/pallets/deeper-node/src/weights.rs
+++ b/pallets/deeper-node/src/weights.rs
@@ -55,6 +55,7 @@ pub trait WeightInfo {
     fn im_online() -> Weight;
     fn report_credit_proof() -> Weight;
     fn reward_mapping() -> Weight;
+    fn get_npow_reward() -> Weight;
 }
 
 /// Weights for pallet_deeper_node using the Substrate node and recommended hardware.
@@ -98,6 +99,11 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
             .saturating_add(T::DbWeight::get().reads(4 as Weight))
             .saturating_add(T::DbWeight::get().writes(2 as Weight))
     }
+    fn get_npow_reward() -> Weight {
+        (41_810_000 as Weight)
+            .saturating_add(T::DbWeight::get().reads(1 as Weight))
+            .saturating_add(T::DbWeight::get().writes(1 as Weight))
+    }
 }
 
 // For backwards compatibility and tests
@@ -139,5 +145,10 @@ impl WeightInfo for () {
         (56_000_000 as Weight)
             .saturating_add(RocksDbWeight::get().reads(4 as Weight))
             .saturating_add(RocksDbWeight::get().writes(2 as Weight))
+    }
+    fn get_npow_reward() -> Weight {
+        (41_810_000 as Weight)
+            .saturating_add(RocksDbWeight::get().reads(1 as Weight))
+            .saturating_add(RocksDbWeight::get().writes(1 as Weight))
     }
 }

--- a/pallets/operation/Cargo.toml
+++ b/pallets/operation/Cargo.toml
@@ -22,7 +22,6 @@ sp-runtime = {default-features = false, git = "https://github.com/paritytech/sub
 sp-std = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19" }
 log = { version = "0.4.14", default-features = false }
 sp-core = {default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.19" }
-pallet-evm = { default-features = false, git = "https://github.com/deeper-chain/frontier.git", branch = "feature/add-npow" }
 pallet-user-privileges = { default-features = false, path = "../user-privileges" }
 
 # Optional imports for benchmarking

--- a/pallets/operation/src/benchmarking.rs
+++ b/pallets/operation/src/benchmarking.rs
@@ -107,16 +107,6 @@ benchmarks! {
         assert_eq!(<T as pallet::Config>::Currency::free_balance(&user),existential_deposit);
     }
 
-    get_npow_reward {
-        let existential_deposit = <T as pallet::Config>::Currency::minimum_balance();
-        let user: T::AccountId = account("user", 0, SEED);
-        let _ = <T as pallet::Config>::Currency::make_free_balance_be(&user, existential_deposit*2u32.into());
-
-        let _ = EvmPallet::<T>::reward_mapping(RawOrigin::Signed(user.clone()).into(),H160::zero());
-    }: _(RawOrigin::Signed(user))
-    verify {
-    }
-
     npow_mint {
         let account: T::AccountId = account("b", 1, USER_SEED);
         let account_lookup: <T::Lookup as StaticLookup>::Source = T::Lookup::unlookup(account.clone());

--- a/pallets/operation/src/lib.rs
+++ b/pallets/operation/src/lib.rs
@@ -45,7 +45,6 @@ pub mod pallet {
         user_privileges::{Privilege, UserPrivilegeInterface},
         OperationInterface, DPR,
     };
-    use pallet_evm::NpowAddressMapping;
     use scale_info::prelude::string::{String, ToString};
     pub use sp_core::H160;
     use sp_runtime::{
@@ -72,7 +71,6 @@ pub mod pallet {
         type BurnedTo: OnUnbalanced<NegativeImbalanceOf<Self>>;
         type MinimumBurnedDPR: Get<BalanceOf<Self>>;
         type CreditInterface: CreditInterface<Self::AccountId, BalanceOf<Self>>;
-        type NpowAddressMapping: NpowAddressMapping<Self::AccountId>;
         type UserPrivilegeInterface: UserPrivilegeInterface<Self::AccountId>;
     }
 
@@ -374,18 +372,6 @@ pub mod pallet {
             T::CreditInterface::burn_record(balance);
             Self::deposit_event(Event::<T>::BurnForEZC(sender, balance, benifity));
             Ok(().into())
-        }
-
-        #[pallet::weight(T::OPWeightInfo::get_npow_reward())]
-        pub fn get_npow_reward(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
-            let sender = ensure_signed(origin)?;
-            match T::NpowAddressMapping::deeper_to_evm(sender.clone()) {
-                Some(evm_address) => {
-                    Self::deposit_event(Event::<T>::GetNpowReward(sender, evm_address));
-                    Ok(().into())
-                }
-                None => Err(Error::<T>::NpowRewardAddressNotFound)?,
-            }
         }
 
         #[pallet::weight(T::OPWeightInfo::npow_mint())]

--- a/pallets/operation/src/tests.rs
+++ b/pallets/operation/src/tests.rs
@@ -26,7 +26,6 @@ use sp_runtime::{
 
 use frame_support::traits::{ConstU32, OnFinalize, OnInitialize};
 use frame_support::{assert_err, assert_ok, parameter_types, weights::Weight};
-use pallet_evm::NpowAddressMapping;
 
 use super::*;
 use crate::{self as pallet_operation};
@@ -127,7 +126,6 @@ impl Config for Test {
     type BurnedTo = ();
     type MinimumBurnedDPR = MinimumBurnedDPR;
     type CreditInterface = ();
-    type NpowAddressMapping = U128FakeNpowAddressMapping;
     type UserPrivilegeInterface = U128FakeUserPrivilege;
 }
 
@@ -226,21 +224,6 @@ fn burn_for_ezc() {
     });
 }
 
-pub struct U128FakeNpowAddressMapping;
-
-impl NpowAddressMapping<u128> for U128FakeNpowAddressMapping {
-    fn evm_to_deeper(_address: H160) -> Option<u128> {
-        None
-    }
-
-    fn deeper_to_evm(address: u128) -> Option<H160> {
-        if address == 1 {
-            return Some(H160::zero());
-        }
-        None
-    }
-}
-
 pub struct U128FakeUserPrivilege;
 
 impl UserPrivilegeInterface<u128> for U128FakeUserPrivilege {
@@ -254,26 +237,6 @@ impl UserPrivilegeInterface<u128> for U128FakeUserPrivilege {
     fn has_evm_privilege(_user: &H160, _p: Privilege) -> bool {
         true
     }
-}
-
-#[test]
-fn get_npow_reward() {
-    new_test_ext().execute_with(|| {
-        run_to_block(1);
-        assert_err!(
-            Operation::get_npow_reward(Origin::signed(2)),
-            Error::<Test>::NpowRewardAddressNotFound
-        );
-
-        assert_ok!(Operation::get_npow_reward(Origin::signed(1)));
-        assert_eq!(
-            <frame_system::Pallet<Test>>::events()
-                .pop()
-                .expect("should contains events")
-                .event,
-            crate::tests::Event::from(crate::Event::GetNpowReward(1, H160::zero()))
-        );
-    });
 }
 
 #[test]

--- a/pallets/operation/src/weights.rs
+++ b/pallets/operation/src/weights.rs
@@ -53,7 +53,6 @@ pub trait WeightInfo {
     fn set_release_limit_parameter() -> Weight;
     fn unstaking_release() -> Weight;
     fn burn_for_ezc() -> Weight;
-    fn get_npow_reward() -> Weight;
     fn npow_mint() -> Weight;
     fn bridge_deeper_to_other() -> Weight;
     fn bridge_other_to_deeper() -> Weight;
@@ -91,13 +90,6 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
             .saturating_add(T::DbWeight::get().reads(1 as Weight))
             .saturating_add(T::DbWeight::get().writes(1 as Weight))
     }
-
-    fn get_npow_reward() -> Weight {
-        (41_810_000 as Weight)
-            .saturating_add(T::DbWeight::get().reads(1 as Weight))
-            .saturating_add(T::DbWeight::get().writes(1 as Weight))
-    }
-
     fn npow_mint() -> Weight {
         (41_810_000 as Weight)
             .saturating_add(T::DbWeight::get().reads(1 as Weight))
@@ -147,13 +139,6 @@ impl WeightInfo for () {
             .saturating_add(RocksDbWeight::get().reads(1 as Weight))
             .saturating_add(RocksDbWeight::get().writes(1 as Weight))
     }
-
-    fn get_npow_reward() -> Weight {
-        (41_810_000 as Weight)
-            .saturating_add(RocksDbWeight::get().reads(1 as Weight))
-            .saturating_add(RocksDbWeight::get().writes(1 as Weight))
-    }
-
     fn npow_mint() -> Weight {
         (41_810_000 as Weight)
             .saturating_add(RocksDbWeight::get().reads(1 as Weight))

--- a/pallets/staking/src/mock.rs
+++ b/pallets/staking/src/mock.rs
@@ -282,7 +282,6 @@ impl pallet_operation::Config for Test {
     type OPWeightInfo = ();
     type MinimumBurnedDPR = MinimumBurnedDPR;
     type CreditInterface = Credit;
-    type NpowAddressMapping = ();
     type UserPrivilegeInterface = UserPrivileges;
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -77,8 +77,7 @@ use fp_rpc::{TransactionStatusV2 as TransactionStatus, TxPoolResponse};
 use pallet_ethereum::{Call::transact, Transaction as EthereumTransaction};
 use pallet_evm::FeeCalculator;
 use pallet_evm::{
-    Account as EVMAccount, EVMCurrencyAdapter, GasWeightMapping, PairedAddressMapping,
-    PairedNpowAddressMapping, Runner,
+    Account as EVMAccount, EVMCurrencyAdapter, GasWeightMapping, PairedAddressMapping, Runner,
 };
 
 mod precompiles;
@@ -483,7 +482,6 @@ impl pallet_operation::Config for Runtime {
     type OPWeightInfo = pallet_operation::weights::SubstrateWeight<Runtime>;
     type MinimumBurnedDPR = MinimumBurnedDPR;
     type CreditInterface = Credit;
-    type NpowAddressMapping = PairedNpowAddressMapping<Runtime>;
     type UserPrivilegeInterface = UserPrivileges;
 }
 


### PR DESCRIPTION
since `reward_mapping` now in pallet-deeper-node, it's better to also move `get_npow_reward` to pallet-deeper-node.
pallet-operation doesn't depends on pallet-evm