### PR TITLE
move npow_mint from operation to staking

### DIFF
--- a/pallets/operation/src/benchmarking.rs
+++ b/pallets/operation/src/benchmarking.rs
@@ -105,17 +105,6 @@ benchmarks! {
         assert_eq!(<T as pallet::Config>::Currency::free_balance(&user),existential_deposit);
     }
 
-    npow_mint {
-        let account: T::AccountId = account("b", 1, USER_SEED);
-        let account_lookup: <T::Lookup as StaticLookup>::Source = T::Lookup::unlookup(account.clone());
-
-        let existential_deposit = <T as pallet::Config>::Currency::minimum_balance();
-        let _ = UserPrivileges::<T>::set_user_privilege(RawOrigin::Root.into(),account_lookup,Privilege::NpowMint);
-        let dpr = existential_deposit * 10u32.into();
-    }: npow_mint(RawOrigin::Signed(account.clone()), account.clone(), dpr)
-    verify {
-    }
-
     bridge_deeper_to_other {
         let user1: T::AccountId = account("b", 1, USER_SEED);
         let user2: T::AccountId = account("b", 2, USER_SEED);

--- a/pallets/operation/src/lib.rs
+++ b/pallets/operation/src/lib.rs
@@ -41,7 +41,7 @@ pub mod pallet {
     use frame_system::pallet_prelude::*;
     use frame_system::{self, ensure_signed};
     use node_primitives::{
-        credit::{CreditInterface, EraIndex},
+        credit::CreditInterface,
         user_privileges::{Privilege, UserPrivilegeInterface},
         OperationInterface, DPR,
     };
@@ -91,8 +91,6 @@ pub mod pallet {
         BurnForEZC(T::AccountId, BalanceOf<T>, H160),
         UnstakingResult(T::AccountId, String),
         GetNpowReward(T::AccountId, H160),
-        NpowMint(T::AccountId, BalanceOf<T>),
-        NpowMintChanged(BalanceOf<T>),
         BridgeDeeperToOther(H160, T::AccountId, BalanceOf<T>, String),
         BridgeOtherToDeeper(T::AccountId, H160, BalanceOf<T>, String),
         DPRPrice(BalanceOf<T>, H160),
@@ -111,7 +109,6 @@ pub mod pallet {
         NpowRewardAddressNotFound,
         FundPoolNotSet,
         PriceDiffTooMuch,
-        NpowMintBeyoundDayLimit,
     }
 
     #[derive(Encode, Decode, Clone, Copy, PartialEq, Eq, RuntimeDebug, MaxEncodedLen, TypeInfo)]
@@ -219,19 +216,6 @@ pub mod pallet {
 
     #[pallet::storage]
     pub(super) type StorageVersion<T> = StorageValue<_, Releases>;
-
-    #[pallet::storage]
-    #[pallet::getter(fn npow_day_minted_dpr)]
-    pub type NpowDayMintedDPR<T: Config> = StorageValue<_, (EraIndex, BalanceOf<T>), OptionQuery>;
-
-    #[pallet::type_value]
-    pub fn NpowMintDayLimitDefault<T: Config>() -> BalanceOf<T> {
-        UniqueSaturatedFrom::unique_saturated_from(100_000 * DPR)
-    }
-    #[pallet::storage]
-    #[pallet::getter(fn npow_mint_day_limit)]
-    pub type NpowMintDayLimit<T: Config> =
-        StorageValue<_, BalanceOf<T>, ValueQuery, NpowMintDayLimitDefault<T>>;
 
     #[pallet::hooks]
     impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
@@ -388,52 +372,6 @@ pub mod pallet {
             T::BurnedTo::on_unbalanced(burned);
             T::CreditInterface::burn_record(balance);
             Self::deposit_event(Event::<T>::BurnForEZC(sender, balance, benifity));
-            Ok(().into())
-        }
-
-        #[pallet::weight(T::OPWeightInfo::npow_mint())]
-        pub fn set_npow_mint_limit(
-            origin: OriginFor<T>,
-            limit: BalanceOf<T>,
-        ) -> DispatchResultWithPostInfo {
-            ensure_root(origin)?;
-            NpowMintDayLimit::<T>::put(limit);
-            Self::deposit_event(Event::<T>::NpowMintChanged(limit));
-            Ok(().into())
-        }
-
-        #[pallet::weight(T::OPWeightInfo::npow_mint())]
-        pub fn npow_mint(
-            origin: OriginFor<T>,
-            target: T::AccountId,
-            dpr: BalanceOf<T>,
-        ) -> DispatchResultWithPostInfo {
-            let who = ensure_signed(origin)?;
-            ensure!(
-                T::UserPrivilegeInterface::has_privilege(&who, Privilege::NpowMint),
-                Error::<T>::UnauthorizedAccounts
-            );
-            let limit = Self::npow_mint_day_limit();
-            ensure!(dpr <= limit, Error::<T>::NpowMintBeyoundDayLimit);
-            let era = T::CreditInterface::get_current_era();
-            match Self::npow_day_minted_dpr() {
-                Some((saved_era, minted_dpr)) => {
-                    if saved_era != era {
-                        NpowDayMintedDPR::<T>::put((era, dpr));
-                    } else {
-                        ensure!(
-                            minted_dpr + dpr <= limit,
-                            Error::<T>::NpowMintBeyoundDayLimit
-                        );
-                        NpowDayMintedDPR::<T>::put((era, minted_dpr + dpr));
-                    }
-                }
-                None => {
-                    NpowDayMintedDPR::<T>::put((era, dpr));
-                }
-            }
-            T::Currency::deposit_creating(&target, dpr);
-            Self::deposit_event(Event::<T>::NpowMint(target, dpr));
             Ok(().into())
         }
 

--- a/pallets/operation/src/tests.rs
+++ b/pallets/operation/src/tests.rs
@@ -25,7 +25,7 @@ use sp_runtime::{
 };
 
 use frame_support::traits::{ConstU32, OnFinalize, OnInitialize};
-use frame_support::{assert_err, assert_ok, parameter_types, weights::Weight};
+use frame_support::{assert_ok, parameter_types, weights::Weight};
 
 use super::*;
 use crate::{self as pallet_operation};
@@ -237,44 +237,6 @@ impl UserPrivilegeInterface<u128> for U128FakeUserPrivilege {
     fn has_evm_privilege(_user: &H160, _p: Privilege) -> bool {
         true
     }
-}
-
-#[test]
-fn npow_mint() {
-    new_test_ext().execute_with(|| {
-        run_to_block(1);
-        assert_ok!(Operation::set_npow_mint_limit(Origin::root(), 100000));
-        assert_ok!(Operation::npow_mint(Origin::signed(1), 2, 100));
-        assert_eq!(
-            <frame_system::Pallet<Test>>::events()
-                .pop()
-                .expect("should contains events")
-                .event,
-            crate::tests::Event::from(crate::Event::NpowMint(2, 100))
-        );
-        run_to_block(2);
-        assert!(Balances::free_balance(&2) > 100);
-
-        assert_err!(
-            Operation::npow_mint(Origin::signed(3), 2, 100),
-            Error::<Test>::UnauthorizedAccounts
-        );
-
-        run_to_block(3);
-        assert_err!(
-            Operation::npow_mint(Origin::signed(1), 2, 100_001),
-            Error::<Test>::NpowMintBeyoundDayLimit
-        );
-        assert_err!(
-            Operation::npow_mint(Origin::signed(1), 2, 99901),
-            Error::<Test>::NpowMintBeyoundDayLimit
-        );
-        assert_ok!(Operation::npow_mint(Origin::signed(1), 2, 99900));
-        assert_err!(
-            Operation::npow_mint(Origin::signed(1), 2, 1),
-            Error::<Test>::NpowMintBeyoundDayLimit
-        );
-    });
 }
 
 #[test]

--- a/pallets/staking/src/benchmarking.rs
+++ b/pallets/staking/src/benchmarking.rs
@@ -405,6 +405,17 @@ benchmarks! {
         let balance_after = <T as Config>::Currency::free_balance(&stash);
         assert!(balance_before > balance_after);
     }
+
+    npow_mint {
+        let account: T::AccountId = account("b", 1, USER_SEED);
+        let account_lookup: <T::Lookup as StaticLookup>::Source = T::Lookup::unlookup(account.clone());
+
+        let existential_deposit = <T as pallet::Config>::Currency::minimum_balance();
+        let _ = UserPrivileges::<T>::set_user_privilege(RawOrigin::Root.into(),account_lookup,Privilege::NpowMint);
+        let dpr = existential_deposit * 10u32.into();
+    }: npow_mint(RawOrigin::Signed(account.clone()), account.clone(), dpr)
+    verify {
+    }
 }
 
 #[cfg(test)]

--- a/pallets/staking/src/lib.rs
+++ b/pallets/staking/src/lib.rs
@@ -2000,13 +2000,12 @@ pub mod pallet {
             let limit = Self::npow_mint_day_limit();
             ensure!(dpr <= limit, Error::<T>::NpowMintBeyoundDayLimit);
 
-            // TODO: use InsufficientMiningRewards when PR 322 got merged
             let remainder_mining_reward = T::NumberToCurrency::convert(
                 Self::remainder_mining_reward().unwrap_or(T::TotalMiningReward::get()),
             );
             ensure!(
                 dpr <= remainder_mining_reward,
-                Error::<T>::NpowMintBeyoundDayLimit
+                Error::<T>::InsufficientValue
             );
 
             let era = T::CreditInterface::get_current_era();

--- a/pallets/staking/src/tests.rs
+++ b/pallets/staking/src/tests.rs
@@ -3232,7 +3232,7 @@ fn npow_mint() {
         RemainderMiningReward::<Test>::put(10000);
         assert_err!(
             Staking::npow_mint(Origin::signed(1), 2, 99900),
-            Error::<Test>::NpowMintBeyoundDayLimit
+            Error::<Test>::InsufficientValue
         );
 
         RemainderMiningReward::<Test>::put(1000000);

--- a/pallets/staking/src/tests.rs
+++ b/pallets/staking/src/tests.rs
@@ -3228,6 +3228,14 @@ fn npow_mint() {
             Staking::npow_mint(Origin::signed(1), 2, 99901),
             Error::<Test>::NpowMintBeyoundDayLimit
         );
+
+        RemainderMiningReward::<Test>::put(10000);
+        assert_err!(
+            Staking::npow_mint(Origin::signed(1), 2, 99900),
+            Error::<Test>::NpowMintBeyoundDayLimit
+        );
+
+        RemainderMiningReward::<Test>::put(1000000);
         assert_ok!(Staking::npow_mint(Origin::signed(1), 2, 99900));
         assert_err!(
             Staking::npow_mint(Origin::signed(1), 2, 1),

--- a/pallets/staking/src/weights.rs
+++ b/pallets/staking/src/weights.rs
@@ -76,6 +76,7 @@ pub trait WeightInfo {
     fn set_history_depth(e: u32) -> Weight;
     fn reap_stash(s: u32) -> Weight;
     fn new_era(v: u32, d: u32) -> Weight;
+    fn npow_mint() -> Weight;
 }
 
 /// Weights for pallet_staking using the Substrate node and recommended hardware.
@@ -232,6 +233,11 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
             .saturating_add(T::DbWeight::get().reads(15 as Weight))
             .saturating_add(T::DbWeight::get().writes(8 as Weight))
     }
+    fn npow_mint() -> Weight {
+        (33_965_000 as Weight)
+            .saturating_add(T::DbWeight::get().reads(2 as Weight))
+            .saturating_add(T::DbWeight::get().writes(1 as Weight))
+    }
 }
 
 // For backwards compatibility and tests
@@ -386,5 +392,10 @@ impl WeightInfo for () {
         (105_590_000 as Weight)
             .saturating_add(RocksDbWeight::get().reads(15 as Weight))
             .saturating_add(RocksDbWeight::get().writes(8 as Weight))
+    }
+    fn npow_mint() -> Weight {
+        (33_965_000 as Weight)
+            .saturating_add(RocksDbWeight::get().reads(2 as Weight))
+            .saturating_add(RocksDbWeight::get().writes(1 as Weight))
     }
 }


### PR DESCRIPTION
Npow mint is a kind of mining, it's better to put it in `pallet-staking`, when mining success, we should also decresse the capacity of the mining pool.