### PR TITLE
optimize code for upgrade

### DIFF
--- a/pallets/staking/src/lib.rs
+++ b/pallets/staking/src/lib.rs
@@ -2966,8 +2966,8 @@ impl<T: Config> pallet::Pallet<T> {
 
     /// Clear all era information for given era.
     fn clear_era_information(era_index: EraIndex) {
-        <ErasStakers<T>>::clear_prefix(era_index, u32::MAX, None);
-        <ErasValidatorPrefs<T>>::clear_prefix(era_index, u32::MAX, None);
+        let _ = <ErasStakers<T>>::clear_prefix(era_index, u32::MAX, None);
+        let _ = <ErasValidatorPrefs<T>>::clear_prefix(era_index, u32::MAX, None);
         <ErasRewardPoints<T>>::remove(era_index);
         <ErasTotalStake<T>>::remove(era_index);
         <ErasValidators<T>>::remove(era_index);

--- a/pallets/staking/src/slashing.rs
+++ b/pallets/staking/src/slashing.rs
@@ -443,7 +443,7 @@ impl<'a, T: 'a + Config> Drop for InspectingSpans<'a, T> {
 
 /// Clear slashing metadata for an obsolete era.
 pub(crate) fn clear_era_metadata<T: Config>(obsolete_era: EraIndex) {
-    <Pallet<T> as Store>::ValidatorSlashInEra::clear_prefix(&obsolete_era, u32::MAX, None);
+    let _ = <Pallet<T> as Store>::ValidatorSlashInEra::clear_prefix(&obsolete_era, u32::MAX, None);
 }
 
 /// Clear slashing metadata for a dead account.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1672,18 +1672,14 @@ impl_runtime_apis! {
 
     impl sp_consensus_babe::BabeApi<Block> for Runtime {
         fn configuration() -> sp_consensus_babe::BabeConfiguration {
-            // The choice of `c` parameter (where `1 - c` represents the
-            // probability of a slot being empty), is done in accordance to the
-            // slot duration and expected target block time, for safely
-            // resisting network delays of maximum two seconds.
-            // <https://research.web3.foundation/en/latest/polkadot/BABE/Babe/#6-practical-results>
+            let epoch_config = Babe::epoch_config().unwrap_or(BABE_GENESIS_EPOCH_CONFIG);
             sp_consensus_babe::BabeConfiguration {
                 slot_duration: Babe::slot_duration(),
                 epoch_length: EpochDuration::get(),
-                c: PRIMARY_PROBABILITY,
+                c: epoch_config.c,
                 authorities: Babe::authorities().to_vec(),
                 randomness: Babe::randomness(),
-                allowed_slots: sp_consensus_babe::AllowedSlots::PrimaryAndSecondaryPlainSlots,
+                allowed_slots: epoch_config.allowed_slots,
             }
         }
 
@@ -1966,6 +1962,17 @@ impl_runtime_apis! {
         }
         fn query_fee_details(uxt: <Block as BlockT>::Extrinsic, len: u32) -> FeeDetails<Balance> {
             TransactionPayment::query_fee_details(uxt, len)
+        }
+    }
+
+    impl pallet_transaction_payment_rpc_runtime_api::TransactionPaymentCallApi<Block, Balance, Call>
+        for Runtime
+    {
+        fn query_call_info(call: Call, len: u32) -> RuntimeDispatchInfo<Balance> {
+            TransactionPayment::query_call_info(call, len)
+        }
+        fn query_call_fee_details(call: Call, len: u32) -> FeeDetails<Balance> {
+            TransactionPayment::query_call_fee_details(call, len)
         }
     }
 


### PR DESCRIPTION
1. `clear_prefix` returns a result type, must be used to avoid warning, it's ok to ignore error cases here.
2. Babe config should be fetched from runtime. https://github.com/paritytech/substrate/pull/11760
3. Query fee and details for `Call`. https://github.com/paritytech/substrate/pull/11819