### PR TITLE
update spec_version:40

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -150,7 +150,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // and set impl_version to 0. If only runtime
     // implementation changes and behavior does not, then leave spec_version as
     // is and increment impl_version.
-    spec_version: 39,
+    spec_version: 40,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 14,


### PR DESCRIPTION
[Adjust the referendum WASM upgrade fee threshold, changing $10,000 / MB for each upgrade to $10 / MB](https://github.com/deeper-chain/deeper-chain/commit/2d688ce08a8c32bbe1f9450103a2e15feb313446)
