### PR TITLE
update spec_version:45

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -173,7 +173,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // and set impl_version to 0. If only runtime
     // implementation changes and behavior does not, then leave spec_version as
     // is and increment impl_version.
-    spec_version: 44,
+    spec_version: 45,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 15,


### PR DESCRIPTION
[reopen staking delegate and not allow staking which has no credit led…](https://github.com/deeper-chain/deeper-chain/commit/ef708ac4b51e7f862aa6fcbe184fc8ad742d4628)