### PR TITLE
update spec_version:46

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -173,7 +173,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // and set impl_version to 0. If only runtime
     // implementation changes and behavior does not, then leave spec_version as
     // is and increment impl_version.
-    spec_version: 45,
+    spec_version: 46,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 15,


### PR DESCRIPTION
[reward_mapping will only use the latest key (](https://github.com/deeper-chain/deeper-chain/commit/1d337464f299f810f5d5f40c11ca3f125eb6e880)https://github.com/deeper-chain/deeper-chain/pull/373[)](https://github.com/deeper-chain/deeper-chain/commit/1d337464f299f810f5d5f40c11ca3f125eb6e880)