### PR TITLE
restore NpowDayMintedDPR

### DIFF
--- a/pallets/staking/src/lib.rs
+++ b/pallets/staking/src/lib.rs
@@ -2169,7 +2169,7 @@ pub mod pallet {
                     DelegatorsKeyPrefix::<T>::put(prefix.clone());
                     DelegatorsLastKey::<T>::put(prefix);
                     NpowDayMintedDPR::<T>::put((era, default_dpr));
-                    weight = weight.saturating_add(T::DbWeight::get().reads_writes(3, 1));
+                    weight = weight.saturating_add(T::DbWeight::get().reads_writes(3, 4));
                 } else {
                     weight = weight.saturating_add(Self::pay_delegators());
                 }

--- a/pallets/staking/src/lib.rs
+++ b/pallets/staking/src/lib.rs
@@ -2161,10 +2161,14 @@ pub mod pallet {
                     let delegator_payouts_per_block =
                         (Self::delegator_count() + paying_blocks_num - 1) / paying_blocks_num + 1;
 
+                    let era = T::CreditInterface::get_current_era();
+                    let default_dpr: BalanceOf<T> = Zero::zero();
+
                     DelegatorPayoutsPerBlock::<T>::put(delegator_payouts_per_block);
                     let prefix = Self::get_delegators_prefix_hash();
                     DelegatorsKeyPrefix::<T>::put(prefix.clone());
                     DelegatorsLastKey::<T>::put(prefix);
+                    NpowDayMintedDPR::<T>::put((era, default_dpr));
                     weight = weight.saturating_add(T::DbWeight::get().reads_writes(3, 1));
                 } else {
                     weight = weight.saturating_add(Self::pay_delegators());


### PR DESCRIPTION
When a very coincidental phenomenon occurs, many small and trivial withdrawals on the same day may be very close to the daily withdrawal limit. As a result, on the next day, no withdrawal amount is small enough to pass the limit threshold and update the records on the chain (ERA, MintedDPR).

As a result, dpr-ezc-bridge always takes a very large MintedDPR and gets stuck.

This PR will reset the withdrawn amount once every Era is updated to prevent similar phenomena from happening.