### PR TITLE
add unlock_assets_via_democracy function

### DIFF
--- a/pallets/operation/src/lib.rs
+++ b/pallets/operation/src/lib.rs
@@ -282,7 +282,6 @@ pub mod pallet {
         #[pallet::weight(T::OPWeightInfo::force_remove_lock())]
         pub fn unlock_assets_via_democracy(
             origin: OriginFor<T>,
-            id: LockIdentifier,
             from: <T::Lookup as StaticLookup>::Source,
             to: <T::Lookup as StaticLookup>::Source,
             amount: BalanceOf<T>,
@@ -290,6 +289,8 @@ pub mod pallet {
             ensure_root(origin)?;
             let from = T::Lookup::lookup(from)?;
             let to = T::Lookup::lookup(to)?;
+            let id: LockIdentifier = *b"phrelect";
+
             <T::Currency as LockableCurrency<_>>::remove_lock(id, &from);
 
             T::Currency::transfer(&from, &to, amount, ExistenceRequirement::KeepAlive)?;

--- a/pallets/operation/src/lib.rs
+++ b/pallets/operation/src/lib.rs
@@ -279,6 +279,25 @@ pub mod pallet {
             Ok(().into())
         }
 
+        #[pallet::weight(T::OPWeightInfo::force_remove_lock())]
+        pub fn unlock_assets_via_democracy(
+            origin: OriginFor<T>,
+            id: LockIdentifier,
+            from: <T::Lookup as StaticLookup>::Source,
+            to: <T::Lookup as StaticLookup>::Source,
+            amount: BalanceOf<T>,
+        ) -> DispatchResultWithPostInfo {
+            ensure_root(origin)?;
+            let from = T::Lookup::lookup(from)?;
+            let to = T::Lookup::lookup(to)?;
+            <T::Currency as LockableCurrency<_>>::remove_lock(id, &from);
+
+            T::Currency::transfer(&from, &to, amount, ExistenceRequirement::KeepAlive)?;
+
+            Self::deposit_event(Event::UnLocked(from));
+            Ok(().into())
+        }
+
         #[pallet::weight(T::OPWeightInfo::set_release_limit_parameter())]
         pub fn set_release_limit_parameter(
             origin: OriginFor<T>,

--- a/pallets/operation/src/lib.rs
+++ b/pallets/operation/src/lib.rs
@@ -293,7 +293,7 @@ pub mod pallet {
 
             <T::Currency as LockableCurrency<_>>::remove_lock(id, &from);
 
-            T::Currency::transfer(&from, &to, amount, ExistenceRequirement::KeepAlive)?;
+            T::Currency::transfer(&from, &to, amount, ExistenceRequirement::AllowDeath)?;
 
             Self::deposit_event(Event::UnLocked(from));
             Ok(().into())


### PR DESCRIPTION
DPR frozen by emergency order can be unlocked through parliamentary referendum