### PR TITLE
Add SOL cross-chain bridge function

### DIFF
--- a/pallets/operation/src/benchmarking.rs
+++ b/pallets/operation/src/benchmarking.rs
@@ -133,5 +133,19 @@ benchmarks! {
     verify {
     }
 
+    apply_for_bridge_transfer {
+        let user1: T::AccountId = account("b", 1, USER_SEED);
+        let user2: T::AccountId = account("b", 2, USER_SEED);
+        let account_lookup: <T::Lookup as StaticLookup>::Source = T::Lookup::unlookup(user1.clone());
+        let _ = UserPrivileges::<T>::set_user_privilege(RawOrigin::Root.into(),account_lookup,Privilege::BridgeAdmin);
+        BridgeFundAddreess::<T>::put(user1.clone());
+        let existential_deposit = <T as pallet::Config>::Currency::minimum_balance();
+        let _ = <T as pallet::Config>::Currency::make_free_balance_be(&user1, existential_deposit*2u32.into());
+        let _ = <T as pallet::Config>::Currency::make_free_balance_be(&user2, existential_deposit*2u32.into());
+
+    }: apply_for_bridge_transfer(RawOrigin::Signed(user1.clone()), "3NwgW4G8pVz7acktRwdMAKfTfw8pFw9h4if5H6P8k9sY".to_string(),existential_deposit,"SOL".to_string())
+    verify {
+    }
+
     impl_benchmark_test_suite!(Operation, crate::tests::new_test_ext(), crate::tests::Test);
 }

--- a/pallets/operation/src/lib.rs
+++ b/pallets/operation/src/lib.rs
@@ -92,8 +92,9 @@ pub mod pallet {
         BurnForEZC(T::AccountId, BalanceOf<T>, H160),
         UnstakingResult(T::AccountId, String),
         GetNpowReward(T::AccountId, H160),
-        BridgeDeeperToOther(H160, T::AccountId, BalanceOf<T>, String),
-        BridgeOtherToDeeper(T::AccountId, H160, BalanceOf<T>, String),
+        BridgeDeeperToOther(String, T::AccountId, BalanceOf<T>, String, String),
+        BridgeOtherToDeeper(T::AccountId, String, BalanceOf<T>, String, String),
+        ApplyForBridgeTransfer(T::AccountId, String, BalanceOf<T>, String),
         DPRPrice(BalanceOf<T>, H160),
         /// Paused transaction
         Paused(String, String, T::AccountId),
@@ -414,10 +415,11 @@ pub mod pallet {
         #[pallet::weight(T::OPWeightInfo::bridge_deeper_to_other())]
         pub fn bridge_deeper_to_other(
             origin: OriginFor<T>,
-            to: H160,
+            to: String,
             from: T::AccountId,
             amount: BalanceOf<T>,
-            tx: String,
+            chain: String,
+            data: String,
         ) -> DispatchResultWithPostInfo {
             let who = ensure_signed(origin)?;
             ensure!(
@@ -433,7 +435,9 @@ pub mod pallet {
                 amount,
                 ExistenceRequirement::KeepAlive,
             )?;
-            Self::deposit_event(Event::<T>::BridgeDeeperToOther(to, from, amount, tx));
+            Self::deposit_event(Event::<T>::BridgeDeeperToOther(
+                to, from, amount, chain, data,
+            ));
             Ok(().into())
         }
 
@@ -442,9 +446,10 @@ pub mod pallet {
         pub fn bridge_other_to_deeper(
             origin: OriginFor<T>,
             to: T::AccountId,
-            from: H160,
+            from: String,
             amount: BalanceOf<T>,
-            tx: String,
+            chain: String,
+            data: String,
         ) -> DispatchResultWithPostInfo {
             let who = ensure_signed(origin)?;
             ensure!(
@@ -460,7 +465,23 @@ pub mod pallet {
                 amount,
                 ExistenceRequirement::KeepAlive,
             )?;
-            Self::deposit_event(Event::<T>::BridgeOtherToDeeper(to, from, amount, tx));
+            Self::deposit_event(Event::<T>::BridgeOtherToDeeper(
+                to, from, amount, chain, data,
+            ));
+            Ok(().into())
+        }
+
+        #[pallet::call_index(9)]
+        #[pallet::weight(T::OPWeightInfo::bridge_deeper_to_other())]
+        pub fn apply_for_bridge_transfer(
+            origin: OriginFor<T>,
+            to: String,
+            amount: BalanceOf<T>,
+            chain: String,
+        ) -> DispatchResultWithPostInfo {
+            let from = ensure_signed(origin)?;
+
+            Self::deposit_event(Event::<T>::ApplyForBridgeTransfer(from, to, amount, chain));
             Ok(().into())
         }
 

--- a/pallets/operation/src/tests.rs
+++ b/pallets/operation/src/tests.rs
@@ -265,12 +265,32 @@ fn bridge_test() {
 
         assert_eq!(Balances::free_balance(&3), 0);
 
+        assert_ok!(Operation::apply_for_bridge_transfer(
+            RuntimeOrigin::signed(1),
+            "3NwgW4G8pVz7acktRwdMAKfTfw8pFw9h4if5H6P8k9sY".to_string(),
+            200,
+            "SOL".to_string()
+        ));
+        assert_eq!(
+            <frame_system::Pallet<Test>>::events()
+                .pop()
+                .expect("should contains events")
+                .event,
+            crate::tests::RuntimeEvent::from(crate::Event::ApplyForBridgeTransfer(
+                1,
+                "3NwgW4G8pVz7acktRwdMAKfTfw8pFw9h4if5H6P8k9sY".to_string(),
+                200,
+                "SOL".to_string()
+            ))
+        );
+
         assert_ok!(Operation::bridge_other_to_deeper(
             RuntimeOrigin::signed(1),
             3,
-            H160::zero(),
+            "3NwgW4G8pVz7acktRwdMAKfTfw8pFw9h4if5H6P8k9sY".to_string(),
             200,
-            "test".to_string()
+            "SOL".to_string(),
+            "1".to_string()
         ));
         assert_eq!(
             <frame_system::Pallet<Test>>::events()
@@ -279,9 +299,10 @@ fn bridge_test() {
                 .event,
             crate::tests::RuntimeEvent::from(crate::Event::BridgeOtherToDeeper(
                 3,
-                H160::zero(),
+                "3NwgW4G8pVz7acktRwdMAKfTfw8pFw9h4if5H6P8k9sY".to_string(),
                 200,
-                "test".to_string()
+                "SOL".to_string(),
+                "1".to_string()
             ))
         );
 
@@ -289,10 +310,11 @@ fn bridge_test() {
 
         assert_ok!(Operation::bridge_deeper_to_other(
             RuntimeOrigin::signed(1),
-            H160::zero(),
+            "3NwgW4G8pVz7acktRwdMAKfTfw8pFw9h4if5H6P8k9sY".to_string(),
             3,
             100,
-            "test".to_string()
+            "SOL".to_string(),
+            "0".to_string()
         ));
         assert_eq!(
             <frame_system::Pallet<Test>>::events()
@@ -300,10 +322,11 @@ fn bridge_test() {
                 .expect("should contains events")
                 .event,
             crate::tests::RuntimeEvent::from(crate::Event::BridgeDeeperToOther(
-                H160::zero(),
+                "3NwgW4G8pVz7acktRwdMAKfTfw8pFw9h4if5H6P8k9sY".to_string(),
                 3,
                 100,
-                "test".to_string()
+                "SOL".to_string(),
+                "0".to_string()
             ))
         );
         assert_eq!(Balances::free_balance(&3), 100);


### PR DESCRIPTION
1. Add apply_for_bridge_transfer withdrawal application method
2. Modify the bridge_other_to_deeper cross-chain method, adjust from(String) to match any network, and add chain identification and data remark fields.
3. Modify the bridge_deeper_to_other cross-chain method, adjust to(String) to match any network, and add chain identification and data remark fields.