### PR TITLE
Bump spec_version to 75 in runtime configuration

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -185,7 +185,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     // and set impl_version to 0. If only runtime
     // implementation changes and behavior does not, then leave spec_version as
     // is and increment impl_version.
-    spec_version: 74,
+    spec_version: 75,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 22,


### PR DESCRIPTION
[add migration for deeper-node's deviceinfo (](https://github.com/deeper-chain/deeper-chain/commit/ec619af0d4c3f2dfcaa848c6c755fbf285a6fd6c)https://github.com/deeper-chain/deeper-chain/pull/438[)](https://github.com/deeper-chain/deeper-chain/commit/ec619af0d4c3f2dfcaa848c6c755fbf285a6fd6c)